### PR TITLE
implement basic drupal permissions

### DIFF
--- a/includes/AnnotationContainer.php
+++ b/includes/AnnotationContainer.php
@@ -97,7 +97,7 @@ class AnnotationContainer implements interfaceAnnotationContainer
             $contentJson["@id"] = $annotationContainerID;
 
             $annotationContainerWithItems  = json_encode($contentJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-            watchdog(AnnotationConstants::MODULE_NAME, 'AnnotationContainer : getAnnotationContainer: Returning @totalItems annotations  for @targetObjectID' . $annotationContainerWithItems, array('@totalItems' => $totalItems, '@targetObjectID'=> $targetObjectID), WATCHDOG_INFO);
+            watchdog(AnnotationConstants::MODULE_NAME, 'AnnotationContainer : getAnnotationContainer: Returning @totalItems annotations  for @targetObjectID', array('@totalItems' => $totalItems, '@targetObjectID'=> $targetObjectID), WATCHDOG_INFO);
 
             return $annotationContainerWithItems;
         }

--- a/includes/AnnotationContainer.php
+++ b/includes/AnnotationContainer.php
@@ -85,6 +85,8 @@ class AnnotationContainer implements interfaceAnnotationContainer
                     $dsContentJson = json_decode($dsContent);
                     $body = $dsContentJson->body;
                     $body->pid = $items[$i];
+                    $body->creator = $dsContentJson->creator;
+                    $body->created = $dsContentJson->created;
                     array_push($newArray, $body);
                 }
             }
@@ -95,7 +97,7 @@ class AnnotationContainer implements interfaceAnnotationContainer
             $contentJson["@id"] = $annotationContainerID;
 
             $annotationContainerWithItems  = json_encode($contentJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-            watchdog(AnnotationConstants::MODULE_NAME, 'AnnotationContainer : getAnnotationContainer: Returning @totalItems annotations  for @argetObjectID', array('@totalItems' => $totalItems, '@targetObjectID'=> $targetObjectID), WATCHDOG_INFO);
+            watchdog(AnnotationConstants::MODULE_NAME, 'AnnotationContainer : getAnnotationContainer: Returning @totalItems annotations  for @targetObjectID' . $annotationContainerWithItems, array('@totalItems' => $totalItems, '@targetObjectID'=> $targetObjectID), WATCHDOG_INFO);
 
             return $annotationContainerWithItems;
         }
@@ -115,7 +117,7 @@ class AnnotationContainer implements interfaceAnnotationContainer
      * @param $annotationData
      * @return jsonld of the annotation that was created
      */
-    public function createAnnotation($targetObjectID, $annotationData){
+    public function createAnnotation($targetObjectID, $annotationData, $annotationMetadata){
         // If annotationContainer does not exist, create the container
         $annotationContainerID = $this->getAnnotationContainerPID($targetObjectID);
         if($annotationContainerID == "None"){
@@ -126,7 +128,7 @@ class AnnotationContainer implements interfaceAnnotationContainer
 
         // Add annotation
         $oAnnotation = new Annotation($this->repository);
-        $annotationInfo = $oAnnotation->createAnnotation($annotationContainerID, $annotationData);
+        $annotationInfo = $oAnnotation->createAnnotation($annotationContainerID, $annotationData, $annotationMetadata);
 
         // Update the container
         $this->addContainerItem($annotationContainerID, $annotationInfo[0]);

--- a/includes/AnnotationController.php
+++ b/includes/AnnotationController.php
@@ -18,9 +18,10 @@ function createAnnotation(){
     {
         $targetObjectID = isset($_POST['targetPid']) ? $_POST['targetPid'] : '';
         $annotationData =  isset($_POST['annotationData']) ? $_POST['annotationData'] : '';
+        $annotationMetadata =  isset($_POST['metadata']) ? $_POST['metadata'] : '';
 
         $oAnnotationContainer = new AnnotationContainer();
-        $output = $oAnnotationContainer->createAnnotation($targetObjectID, $annotationData);
+        $output = $oAnnotationContainer->createAnnotation($targetObjectID, $annotationData, $annotationMetadata);
     } catch(Exception $e) {
         watchdog(AnnotationConstants::MODULE_NAME, 'Error in createAnnotation: %t', array('%t' => $e->getMessage()), WATCHDOG_ERROR);
         $output = array('status' => "Fail", "msg"=> "Failed to create annotation for targetObjectID " . $targetObjectID);
@@ -58,9 +59,10 @@ function updateAnnotation(){
         parse_str(file_get_contents("php://input"), $putVars);
         $annotationData = $putVars['annotationData'] ? $putVars['annotationData'] : '';
         $annotationID = $annotationData["pid"];
+        $annotationMetadata = $putVars['metadata'] ? $putVars['metadata'] : '';
 
         $oAnnotation = new Annotation();
-        $output = $oAnnotation->updateAnnotation($annotationData);
+        $output = $oAnnotation->updateAnnotation($annotationData, $annotationMetadata);
     } catch(Exception $e) {
 
         $output = array('status' => "Fail", "msg"=> "Failed to updateAnnotation with annotation with PID " . $annotationID);

--- a/includes/interfaceAnnotation.php
+++ b/includes/interfaceAnnotation.php
@@ -6,7 +6,7 @@
 
 interface interfaceAnnotation {
 
-    public function createAnnotation($annotationContainerID, $annotationInfo);
-    public function updateAnnotation($annotationID);
+    public function createAnnotation($annotationContainerID, $annotationInfo, $annotationMetadata);
+    public function updateAnnotation($annotationID, $annotationMetadata);
     public function deleteAnnotation($annotationID);
 }

--- a/includes/interfaceAnnotationContainer.php
+++ b/includes/interfaceAnnotationContainer.php
@@ -39,7 +39,7 @@ interface interfaceAnnotationContainer {
      * @param $annotationInfo
      * @return mixed
      */
-    public function createAnnotation($targetObjectID, $annotationData);
+    public function createAnnotation($targetObjectID, $annotationData, $annotationMetadata);
 
 
     /**

--- a/islandora_web_annotations.module
+++ b/islandora_web_annotations.module
@@ -129,6 +129,10 @@ function islandora_web_annotations_permission() {
  * Send user access related information to js for access control
  */
 function islandora_web_annotations_init() {
+    global $user;
+    $username = $user->name;
+
+
     $view = user_access(ISLANDORA_WEB_ANNOTATION_VIEW);
     $create = user_access(ISLANDORA_WEB_ANNOTATION_CREATE);
     $edit_any = user_access(ISLANDORA_WEB_ANNOTATION_EDIT_ANY);
@@ -136,7 +140,7 @@ function islandora_web_annotations_init() {
     $edit_own = user_access(ISLANDORA_WEB_ANNOTATION_EDIT_OWN);
     $delete_own = user_access(ISLANDORA_WEB_ANNOTATION_DELETE_OWN);
 
-    drupal_add_js(array('islandora_web_annotations' => array('view' => $view, 'create'=>$create, 'edit_any'=>$edit_any, 'delete_any'=>$delete_any, 'edit_own'=>$edit_own, 'delete_own'=>$delete_own)), array('type' => 'setting'));
+    drupal_add_js(array('islandora_web_annotations' => array('user'=>$username, 'view' => $view, 'create'=>$create, 'edit_any'=>$edit_any, 'delete_any'=>$delete_any, 'edit_own'=>$edit_own, 'delete_own'=>$delete_own)), array('type' => 'setting'));
 }
 
 

--- a/islandora_web_annotations.module
+++ b/islandora_web_annotations.module
@@ -130,8 +130,12 @@ function islandora_web_annotations_permission() {
  */
 function islandora_web_annotations_init() {
     global $user;
-    $username = $user->name;
+    $username = "anonymous";
 
+    if (isset($user->name)) {
+        watchdog("annotations", "not anno");
+        $username = $user->name;
+    }
 
     $view = user_access(ISLANDORA_WEB_ANNOTATION_VIEW);
     $create = user_access(ISLANDORA_WEB_ANNOTATION_CREATE);

--- a/islandora_web_annotations.module
+++ b/islandora_web_annotations.module
@@ -12,6 +12,13 @@
  * Examples using Drupal 7's built-in JavaScript.
  */
 
+define('ISLANDORA_WEB_ANNOTATION_VIEW', 'View Web Annotations');
+define('ISLANDORA_WEB_ANNOTATION_CREATE', 'Create Web Annotations');
+define('ISLANDORA_WEB_ANNOTATION_EDIT_ANY', 'Edit any Web Annotations');
+define('ISLANDORA_WEB_ANNOTATION_DELETE_ANY', 'Delete Any Web Annotations');
+define('ISLANDORA_WEB_ANNOTATION_EDIT_OWN', 'Edit Own Web Annotations');
+define('ISLANDORA_WEB_ANNOTATION_DELETE_OWN', 'Delete Own Web Annotations');
+
 /**
  * Implements hook_theme().
  */
@@ -40,6 +47,7 @@ function islandora_web_annotations_menu() {
         'page callback' => 'createAnnotation',
         'access callback' => TRUE,
         'file' => 'includes/AnnotationController.php',
+        'access arguments' => array(ISLANDORA_WEB_ANNOTATION_CREATE),
         'type' => MENU_CALLBACK,
     );
 
@@ -49,6 +57,7 @@ function islandora_web_annotations_menu() {
         'page callback' => 'getAnnotationContainer',
         'access callback' => TRUE,
         'file' => 'includes/AnnotationController.php',
+        'access arguments' => array(ISLANDORA_WEB_ANNOTATION_VIEW),
         'type' => MENU_CALLBACK,
     );
 
@@ -58,6 +67,7 @@ function islandora_web_annotations_menu() {
         'page callback' => 'updateAnnotation',
         'access callback' => TRUE,
         'file' => 'includes/AnnotationController.php',
+        'access arguments' => array(ISLANDORA_WEB_ANNOTATION_EDIT_ANY, ISLANDORA_WEB_ANNOTATION_EDIT_OWN),
         'type' => MENU_CALLBACK,
     );
 
@@ -67,6 +77,7 @@ function islandora_web_annotations_menu() {
         'page callback' => 'deleteAnnotation',
         'access callback' => TRUE,
         'file' => 'includes/AnnotationController.php',
+        'access arguments' => array(ISLANDORA_WEB_ANNOTATION_DELETE_ANY, ISLANDORA_WEB_ANNOTATION_DELETE_OWN),
         'type' => MENU_CALLBACK,
     );
 
@@ -81,6 +92,53 @@ function islandora_web_annotations_menu() {
 
     return $items;
 }
+
+/**
+ * Implements hook_permission().
+ */
+function islandora_web_annotations_permission() {
+    return array(
+        ISLANDORA_WEB_ANNOTATION_VIEW => array(
+            'title' => t('View web annotations'),
+            'description' => t('view web annotations.'),
+        ),
+        ISLANDORA_WEB_ANNOTATION_CREATE => array(
+            'title' => t('Create web annotations'),
+            'description' => t('create web annotations'),
+        ),
+        ISLANDORA_WEB_ANNOTATION_EDIT_ANY => array(
+            'title' => t('Edit any web annotations'),
+            'description' => t('edit any web annotations'),
+        ),
+        ISLANDORA_WEB_ANNOTATION_DELETE_ANY => array(
+            'title' => t('Delete any web annotations'),
+            'description' => t('delete any web annotations'),
+        ),
+        ISLANDORA_WEB_ANNOTATION_EDIT_OWN => array(
+            'title' => t('Edit own web annotations'),
+            'description' => t('edit own web annotations'),
+        ),
+        ISLANDORA_WEB_ANNOTATION_DELETE_OWN => array(
+            'title' => t('Delete own web annotations'),
+            'description' => t('delete own web annotations'),
+        ),
+    );
+}
+
+/**
+ * Send user access related information to js for access control
+ */
+function islandora_web_annotations_init() {
+    $view = user_access(ISLANDORA_WEB_ANNOTATION_VIEW);
+    $create = user_access(ISLANDORA_WEB_ANNOTATION_CREATE);
+    $edit_any = user_access(ISLANDORA_WEB_ANNOTATION_EDIT_ANY);
+    $delete_any = user_access(ISLANDORA_WEB_ANNOTATION_DELETE_ANY);
+    $edit_own = user_access(ISLANDORA_WEB_ANNOTATION_EDIT_OWN);
+    $delete_own = user_access(ISLANDORA_WEB_ANNOTATION_DELETE_OWN);
+
+    drupal_add_js(array('islandora_web_annotations' => array('view' => $view, 'create'=>$create, 'edit_any'=>$edit_any, 'delete_any'=>$delete_any, 'edit_own'=>$edit_own, 'delete_own'=>$delete_own)), array('type' => 'setting'));
+}
+
 
 /**
  * Demonstrate accordion effect.

--- a/js/basic_image/basic_image.js
+++ b/js/basic_image/basic_image.js
@@ -10,14 +10,21 @@ jQuery(document).ready(function() {
     var m_image = jQuery("div[class='islandora-basic-image-content']").find("img[typeof='foaf:Image']").first();
     jQuery(m_image).unwrap();
 
-    var loadAnnotationsButton = jQuery('<button id="load-annotation-button" title="Load Annotations" class="annotator-adder-actions__button h-icon-annotate" onclick="getAnnotationsBasicImage()"></button>');
-    loadAnnotationsButton.appendTo(jQuery(".islandora-basic-image-content")[0]);
+    if(Drupal.settings.islandora_web_annotations.view == true) {
+        var loadAnnotationsButton = jQuery('<button id="load-annotation-button" title="Load Annotations" class="annotator-adder-actions__button h-icon-annotate" onclick="getAnnotationsBasicImage()"></button>');
+        loadAnnotationsButton.appendTo(jQuery(".islandora-basic-image-content")[0]);
+    }
 
     anno.makeAnnotatable(m_image[0]);
 
     anno.addHandler("onAnnotationCreated", function(annotation) {
-        var objectPID = getBasicImagePID();
-        createAnnotation(objectPID, annotation);
+        if(Drupal.settings.islandora_web_annotations.create == true) {
+            var objectPID = getBasicImagePID();
+            createAnnotation(objectPID, annotation);
+        } else {
+            alert("You do not have permissions to save annotations for basic image.");
+        }
+
     });
 
     anno.addHandler("onAnnotationUpdated", function(annotation) {
@@ -30,6 +37,19 @@ jQuery(document).ready(function() {
 
     jQuery(".annotorious-hint").css("left", "45px");
 
+    // Apply permissions to edit, delete annotations
+    anno.addHandler("onPopupShown", function() {
+        jQuery(".annotorious-popup-button-edit").hide();
+        jQuery(".annotorious-popup-button-delete").hide();
+
+        if(Drupal.settings.islandora_web_annotations.edit_any == true || Drupal.settings.islandora_web_annotations.edit_own == true) {
+            jQuery(".annotorious-popup-button-edit").show();
+        }
+        if(Drupal.settings.islandora_web_annotations.delete_any == true || Drupal.settings.islandora_web_annotations.delete_own == true) {
+            jQuery(".annotorious-popup-button-delete").show();
+        }
+    });
+
 });
 
 
@@ -40,8 +60,7 @@ function getAnnotationsBasicImage() {
 
 
 function getBasicImagePID() {
-    var objectURL = Drupal.settings.urlIsAjaxTrusted;
-    objectURL = Object.keys(objectURL)[0];
+    var objectURL = window.location.href;
     var objectPID = objectURL.substr(objectURL.lastIndexOf('/') + 1);
     objectPID = objectPID.replace("%3A", ":");
     return objectPID;

--- a/js/basic_image/basic_image.js
+++ b/js/basic_image/basic_image.js
@@ -20,11 +20,11 @@ jQuery(document).ready(function() {
     anno.addHandler("onAnnotationCreated", function(annotation) {
         if(Drupal.settings.islandora_web_annotations.create == true) {
             var objectPID = getBasicImagePID();
+            annotation.pid = "New";
             createAnnotation(objectPID, annotation);
         } else {
             alert("You do not have permissions to save annotations for basic image.");
         }
-
     });
 
     anno.addHandler("onAnnotationUpdated", function(annotation) {
@@ -37,18 +37,8 @@ jQuery(document).ready(function() {
 
     jQuery(".annotorious-hint").css("left", "45px");
 
-    // Apply permissions to edit, delete annotations
-    anno.addHandler("onPopupShown", function() {
-        jQuery(".annotorious-popup-button-edit").hide();
-        jQuery(".annotorious-popup-button-delete").hide();
+    executeCommonLoadOperations();
 
-        if(Drupal.settings.islandora_web_annotations.edit_any == true || Drupal.settings.islandora_web_annotations.edit_own == true) {
-            jQuery(".annotorious-popup-button-edit").show();
-        }
-        if(Drupal.settings.islandora_web_annotations.delete_any == true || Drupal.settings.islandora_web_annotations.delete_own == true) {
-            jQuery(".annotorious-popup-button-delete").show();
-        }
-    });
 
 });
 

--- a/js/large_image/large_image.js
+++ b/js/large_image/large_image.js
@@ -23,12 +23,15 @@ jQuery(document).ready(function() {
     openSeaDragonDiv.wrap('<div class="islandora-openseadragon" id="openseadragon-wrapper"></div>');
 
 
-    var saveButton = jQuery('<button id="load-annotation-button" title="Load Annotations" class="annotator-adder-actions__button h-icon-annotate" onclick="getAnnotationsLargeImage()"></button>');
-    saveButton.appendTo(jQuery("#openseadragon-wrapper"));
+    if(Drupal.settings.islandora_web_annotations.view == true) {
+        var saveButton = jQuery('<button id="load-annotation-button" title="Load Annotations" class="annotator-adder-actions__button h-icon-annotate" onclick="getAnnotationsLargeImage()"></button>');
+        saveButton.appendTo(jQuery("#openseadragon-wrapper"));
+    }
 
-
-    var addButton = jQuery('<button id="add-annotation-button" title="Add Annotation" class="annotator-adder-actions__button h-icon-add" onclick="anno.activateSelector();"></button>');
-    addButton.appendTo(jQuery("#openseadragon-wrapper"));
+    if(Drupal.settings.islandora_web_annotations.create == true) {
+        var addButton = jQuery('<button id="add-annotation-button" title="Add Annotation" class="annotator-adder-actions__button h-icon-add" onclick="anno.activateSelector();"></button>');
+        addButton.appendTo(jQuery("#openseadragon-wrapper"));
+    }
 
 
     var os_viewer = Drupal.settings.islandora_open_seadragon_viewer;
@@ -48,9 +51,21 @@ jQuery(document).ready(function() {
     });
 
     anno.addHandler("onAnnotationRemoved", function(annotation) {
-        deleteAnnotation(annotation);
+            deleteAnnotation(annotation);
     });
 
+    // Apply permissions to edit, delete annotations
+    anno.addHandler("onPopupShown", function() {
+        jQuery(".annotorious-popup-button-edit").hide();
+        jQuery(".annotorious-popup-button-delete").hide();
+
+        if(Drupal.settings.islandora_web_annotations.edit_any == true || Drupal.settings.islandora_web_annotations.edit_own == true) {
+            jQuery(".annotorious-popup-button-edit").show();
+        }
+        if(Drupal.settings.islandora_web_annotations.delete_any == true || Drupal.settings.islandora_web_annotations.delete_own == true) {
+            jQuery(".annotorious-popup-button-delete").show();
+        }
+    });
 });
 
 

--- a/js/large_image/large_image.js
+++ b/js/large_image/large_image.js
@@ -43,6 +43,7 @@ jQuery(document).ready(function() {
 
     anno.addHandler("onAnnotationCreated", function(annotation) {
         var targetObjectId = Drupal.settings.islandoraOpenSeadragon.pid;
+        annotation.pid = "New";
         createAnnotation(targetObjectId, annotation);
     });
 
@@ -54,18 +55,7 @@ jQuery(document).ready(function() {
             deleteAnnotation(annotation);
     });
 
-    // Apply permissions to edit, delete annotations
-    anno.addHandler("onPopupShown", function() {
-        jQuery(".annotorious-popup-button-edit").hide();
-        jQuery(".annotorious-popup-button-delete").hide();
-
-        if(Drupal.settings.islandora_web_annotations.edit_any == true || Drupal.settings.islandora_web_annotations.edit_own == true) {
-            jQuery(".annotorious-popup-button-edit").show();
-        }
-        if(Drupal.settings.islandora_web_annotations.delete_any == true || Drupal.settings.islandora_web_annotations.delete_own == true) {
-            jQuery(".annotorious-popup-button-delete").show();
-        }
-    });
+    executeCommonLoadOperations();
 });
 
 


### PR DESCRIPTION
This PR is for [issue#20](https://github.com/digitalutsc/islandora_web_annotations/issues/20).  It implements basic drupal access permissions for web annotations.  

It passes on the access information to js and js checks for allowed operations for a user.  The hook_menu paths are also restricted by permissions.  