### PR TITLE
Implement basic Solr search of the annotation

### DIFF
--- a/includes/AnnotationUtil.php
+++ b/includes/AnnotationUtil.php
@@ -27,4 +27,68 @@ class AnnotationUtil
         return sprintf('%04X%04X-%04X-%04X-%04X-%04X%04X%04X', mt_rand(0, 65535), mt_rand(0, 65535), mt_rand(0, 65535), mt_rand(16384, 20479), mt_rand(32768, 49151), mt_rand(0, 65535), mt_rand(0, 65535), mt_rand(0, 65535));
     }
 
+    /**
+     * Adds the given file as a datastream to the given object.
+     *
+     * @param AbstractObject $object
+     *   An AbstractObject representing an object within Fedora.
+     * @param string $datastream_id
+     *   The datastream id of the added datastream.
+     * @param string $file_uri
+     *   A URI to the file containing the content for the datastream.
+     *
+     * @return array
+     *   An array describing the outcome of the datastream addition.
+     */
+    public static function add_datastream(AbstractObject $object, $datastream_id, $file_uri) {
+        self::initialize();
+
+        try {
+            $ingest = !isset($object[$datastream_id]);
+            $mime_detector = new MimeDetect();
+            if ($ingest) {
+                $ds = $object->constructDatastream($datastream_id, "M");
+                $ds->label = $datastream_id;
+            }
+            else {
+                $ds = $object[$datastream_id];
+            }
+            $ds->mimetype = $mime_detector->getMimetype($file_uri);
+            $ds->setContentFromFile(drupal_realpath($file_uri));
+            if ($ingest) {
+                $object->ingestDatastream($ds);
+            }
+            return array(
+                'success' => TRUE,
+                'messages' => array(
+                    array(
+                        'message' => t('Created @dsid derivative for (@pid).'),
+                        'message_sub' => array(
+                            '@dsid' => $datastream_id,
+                            '@pid' => $object->id,
+                        ),
+                        'type' => 'dsm',
+                    ),
+                ),
+            );
+        }
+        catch (exception $e) {
+            return array(
+                'success' => FALSE,
+                'messages' => array(
+                    array(
+                        'message' => t('Oral Histories solution pack failed to add @dsid datastream for @pid. Error message: @message<br/>Stack: @stack'),
+                        'message_sub' => array(
+                            '@dsid' => $datastream_id,
+                            '@pid' => $object->id,
+                            '@message' => $e->getmessage(),
+                            '@stack' => $e->getTraceAsString(),
+                        ),
+                        'type' => 'watchdog',
+                        'severity' => WATCHDOG_ERROR,
+                    ),
+                ),
+            );
+        }
+    }
 }

--- a/xsl/annotation_solr.xslt
+++ b/xsl/annotation_solr.xslt
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ORALHISTORIES TRANSCRIPT -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:foxml="info:fedora/fedora-system:def/foxml#" xmlns:dcterms="http://purl.org/dc/terms/">
+    <xsl:template match="foxml:datastream[@ID='WADM_SEARCH']/foxml:datastreamVersion[last()]" name="index_ANNOTATION">
+        <xsl:param name="content"/>
+            <field name="annotation_title">
+                <xsl:value-of select="$content//title"/>
+            </field>
+            <field name="annotation_value">
+                <xsl:value-of select="$content//textvalue"/>
+            </field>
+
+    </xsl:template>
+
+</xsl:stylesheet>
+


### PR DESCRIPTION
## What does this PR do?
This PR creates a derivative of an annotation for solr indexing purposes  https://github.com/digitalutsc/islandora_web_annotations/issues/16.  Derivative with datastream id of WADM_SEARCH is created/updated when an annotation is created or updated.  

## How can I test it?
1 Get the PR.  
2 Configure the Solr
- Copy the xslt 
```
> cd /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/
> cp /var/www/drupal/sites/all/modules/islandora_web_annotations/xsl/annotation_solr.xslt ./
```
- Edit foxmlToSolr.xslt, and add the following line
```
<xsl:include href="/var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/annotation_solr.xslt"/>
```

- Edit /usr/local/solr/collection1/conf/schema.xml and add the following dynamicfield:
```
<dynamicField name="annotation_*" type="text" indexed="true" stored="true" multiValued="true"/>
```

- Restart the tomcat

3. Create a new annotation.  Search for that annotation in Solr using the PID.  Ensure that the annotation related fields are added: example:
```
   <arr name="annotation_title">
      <str>Annotation for islandora%3A218</str>
    </arr>
    <arr name="annotation_value">
      <str>test annotation value</str>
    </arr>
```

4. Alternatively you can add the annotation related fields to Advanced Search and search it via the Drupal UI.