### PR TITLE
use ETag/checksum to support multiuser edits

### DIFF
--- a/includes/Annotation.php
+++ b/includes/Annotation.php
@@ -49,12 +49,19 @@ class Annotation implements interfaceAnnotation
             $this->repository->ingestObject($object);
             $annotationPID =  $object->id;
 
+
             // Create Derivative
             $contentXML = $this->generateDerivativeContent($annotationData, $annotationMetadata);
             $this->createUpdateDerivative($object, $contentXML);
 
             // Update JsonLD with PID info
             $annotationJsonLDData["pid"] = $annotationPID;
+
+            // Get WADM ds checksum
+            $WADMObject = $object->getDatastream(AnnotationConstants::WADM_DSID);
+            $checksum =  $WADMObject->checksum;
+
+            $annotationJsonLDData["checksum"] = $checksum;
             $annotationJsonLD = json_encode($annotationJsonLDData, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 
             watchdog(AnnotationConstants::MODULE_NAME , 'Annotation : createAnnotation: Added new annotation @annotationPID', array("@annotationPID" => $annotationPID), WATCHDOG_INFO);
@@ -82,12 +89,30 @@ class Annotation implements interfaceAnnotation
         $contentXML = $this->generateDerivativeContent($annotationData, $annotationMetadata);
         $this->createUpdateDerivative($object, $contentXML);
 
-        return $updatedContent;
+        return $annotationJsonLDData;
     }
 
     public function deleteAnnotation($annotationID){
         $this->repository->purgeObject($annotationID);
         watchdog(AnnotationConstants::MODULE_NAME, 'Annotation: deleteAnnotation: Annotation with id @deleteAnnotation was deleted from repoistory.', array('@annotationID'=>$annotationID), WATCHDOG_INFO);
+    }
+
+    /**
+     * Gets the current checksum and compares it with the ETag checksum to check if the datastream has been alstered
+     * @param $annotationID
+     * @param $ETag
+     * @return bool - If conflict exists, return true, else false
+     */
+    public function checkEditConflict($annotationID, $ETag){
+        $object = $this->repository->getObject($annotationID);
+        $WADMObject = $object->getDatastream(AnnotationConstants::WADM_DSID);
+        $checksum = $WADMObject->checksum;
+
+        if (strcmp($checksum, $ETag) !== 0) {
+            return false;
+        } else {
+            return true;
+        }
     }
 
     private function getAnnotationJsonLD($actionType, $annotationData, $annotationMetadata)
@@ -117,7 +142,7 @@ class Annotation implements interfaceAnnotation
         return $data;
     }
 
-    function createUpdateDerivative(AbstractObject $object, $contentXML){
+    private function createUpdateDerivative(AbstractObject $object, $contentXML){
         try {
 
             $dsid = 'WADM_SEARCH';
@@ -141,7 +166,7 @@ class Annotation implements interfaceAnnotation
         }
     }
 
-    function generateDerivativeContent($annotationData, $annotationMetadata){
+    private function generateDerivativeContent($annotationData, $annotationMetadata){
         $target = $annotationData["context"];
         $pos = strrpos($target, '/');
         $targetID = $pos === false ? $target : substr($target, $pos + 1);

--- a/includes/Annotation.php
+++ b/includes/Annotation.php
@@ -40,7 +40,6 @@ class Annotation implements interfaceAnnotation
             $annotationJsonLDData = $this->getAnnotationJsonLD("create", $annotationData, $annotationMetadata);
             $annotationJsonLD = json_encode($annotationJsonLDData, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 
-
             $ds = $object->constructDatastream($dsid, 'M');
             $ds->label = $dsid;
             $ds->mimetype = AnnotationConstants::ANNOTATION_MIMETYPE;
@@ -48,7 +47,6 @@ class Annotation implements interfaceAnnotation
             $object->ingestDatastream($ds);
             $this->repository->ingestObject($object);
             $annotationPID =  $object->id;
-
 
             // Create Derivative
             $contentXML = $this->generateDerivativeContent($annotationData, $annotationMetadata);
@@ -79,11 +77,14 @@ class Annotation implements interfaceAnnotation
         $annotationJsonLDData = $this->getAnnotationJsonLD("update", $annotationData, $annotationMetadata);
         $updatedContent = json_encode($annotationJsonLDData, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 
-
         $object = $this->repository->getObject($annotationPID);
         $WADMObject = $object->getDatastream(AnnotationConstants::WADM_DSID);
         $WADMObject->content = $updatedContent;
 
+        // Get WADM ds checksum
+        $WADMObject = $object->getDatastream(AnnotationConstants::WADM_DSID);
+        $checksum =  $WADMObject->checksum;
+        $annotationJsonLDData["checksum"] = $checksum;
 
         // Update Derivative
         $contentXML = $this->generateDerivativeContent($annotationData, $annotationMetadata);

--- a/includes/AnnotationContainer.php
+++ b/includes/AnnotationContainer.php
@@ -80,6 +80,7 @@ class AnnotationContainer implements interfaceAnnotationContainer
                 $object = $this->repository->getObject($items[$i]);
                 $WADMObject = $object->getDatastream(AnnotationConstants::WADM_DSID);
                 $dsContent = (string)$WADMObject->content;
+                $checksum = $WADMObject->checksum;
 
                 if($dsContent != "NotFound") {
                     $dsContentJson = json_decode($dsContent);
@@ -87,6 +88,7 @@ class AnnotationContainer implements interfaceAnnotationContainer
                     $body->pid = $items[$i];
                     $body->creator = $dsContentJson->creator;
                     $body->created = $dsContentJson->created;
+                    $body->checksum = $checksum;
                     array_push($newArray, $body);
                 }
             }
@@ -163,7 +165,7 @@ class AnnotationContainer implements interfaceAnnotationContainer
         $oAnnotation->deleteAnnotation($annotationID);
 
         // Return message
-        $output = array('status' => "Success", "msg"=> "The following annotation was deleted: " . $annotationID);
+        $output = array('status' => "success", "data"=> "The following annotation was deleted: " . $annotationID);
         $output = json_encode($output);
 
         return $output;

--- a/includes/AnnotationController.php
+++ b/includes/AnnotationController.php
@@ -43,7 +43,7 @@ function getAnnotationContainer(){
     } catch(Exception $e)
     {
         watchdog(AnnotationConstants::MODULE_NAME, 'Error in getAnnotationContainer: %t', array('%t' => $e->getMessage()), WATCHDOG_ERROR);
-        $output = array('status' => "Fail", "msg"=> "Failed to get annotationContainer for targetObjectID " . $targetObjectID);
+        $output = array('status' => "failure", "msg"=> "Failed to get annotationContainer for targetObjectID " . $targetObjectID);
         $output = json_encode($output);
     }
 
@@ -61,11 +61,23 @@ function updateAnnotation(){
         $annotationID = $annotationData["pid"];
         $annotationMetadata = $putVars['metadata'] ? $putVars['metadata'] : '';
 
+        $ETag = $_SERVER['HTTP_IF_MATCH'];
         $oAnnotation = new Annotation();
-        $output = $oAnnotation->updateAnnotation($annotationData, $annotationMetadata);
-    } catch(Exception $e) {
+        $bConflict = $oAnnotation->checkEditConflict($annotationID, $ETag);
 
-        $output = array('status' => "Fail", "msg"=> "Failed to updateAnnotation with annotation with PID " . $annotationID);
+        // If conflict exists, return message
+        if($bConflict == false){
+            $output = array('status' => "conflict", "data"=> "The original datastream has been changed for " . $annotationID);
+            $output = json_encode($output);
+        } else {
+            $output = $oAnnotation->updateAnnotation($annotationData, $annotationMetadata);
+            $output = array('status' => "success", "data"=> $output);
+            $output = json_encode($output, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        }
+
+    } catch(Exception $e) {
+        watchdog(AnnotationConstants::MODULE_NAME, 'Error in updateAnnotation: %t', array('%t' => $e->getMessage()), WATCHDOG_ERROR);
+        $output = array('status' => "failure", "data"=> "Failed to updateAnnotation with annotation with PID " . $annotationID);
         $output = json_encode($output);
     }
 
@@ -78,13 +90,24 @@ function deleteAnnotation(){
     try {
         parse_str(file_get_contents("php://input"), $deleteVars);
         $annotationID = $deleteVars['annotationID'] ? $deleteVars['annotationID'] : '';
-
         $annotationContainerID = $deleteVars['annotationContainerID'] ? $deleteVars['annotationContainerID'] : '';
+        $ETag = $_SERVER['HTTP_IF_MATCH'];
 
-        $oAnnotationContainer = new AnnotationContainer();
-        $output = $oAnnotationContainer->deleteAnnotation($annotationContainerID, $annotationID);
+        // Delete the object
+        $oAnnotation = new Annotation();
+        $bConflict = $oAnnotation->checkEditConflict($annotationID, $ETag);
+
+        // If conflict exists, return message
+        if($bConflict == false){
+            $output = array('status' => "conflict", "data"=> "The original datastream has been changed for " . $annotationID);
+            $output = json_encode($output);
+        } else {
+            $oAnnotationContainer = new AnnotationContainer();
+            $output = $oAnnotationContainer->deleteAnnotation($annotationContainerID, $annotationID);
+        }
     } catch(Exception $e)  {
-        $output = array('status' => "Fail", "msg"=> "Failed to deleteAnnotation with annotation with PID " . $annotationID);
+        watchdog(AnnotationConstants::MODULE_NAME, 'Error in deleteAnnotation: %t', array('%t' => $e->getMessage()), WATCHDOG_ERROR);
+        $output = array('status' => "failure", "data"=> "Failed to deleteAnnotation with annotation with PID " . $annotationID);
         $output = json_encode($output);
     }
     drupal_json_output($output);

--- a/js/base/base.js
+++ b/js/base/base.js
@@ -52,7 +52,7 @@ function createAnnotation(targetObjectId, annotationData) {
             var created = jsonData.created;
             var checksum = jsonData.checksum;
 
-            updateNewAnnotationInfo(pid, creator, created);
+            updateNewAnnotationInfo(pid, creator, created, checksum);
             insertLabelForNewAnnotation(pid, annotationData);
             alert("Successfully created annotation: " + data);
         }
@@ -62,13 +62,14 @@ function createAnnotation(targetObjectId, annotationData) {
 }
 
 // We need to update the current annnotation datastore with pid and other info to preform operations and enforce access
-function updateNewAnnotationInfo(pid, creator, created) {
+function updateNewAnnotationInfo(pid, creator, created, checksum) {
     var annotations = anno.getAnnotations()
     for(var j = 0; j < annotations.length; j++){
         if(annotations[j].pid == "New") {
             annotations[j].pid = pid;
             annotations[j].creator = creator;
             annotations[j].created = created;
+            annotations[j].checksum = checksum;
             break;
         }
     }

--- a/js/base/base.js
+++ b/js/base/base.js
@@ -191,6 +191,9 @@ function updateAnnotation(annotationData) {
             var jsonData = JSON.parse(data);
             var status = jsonData.status;
             var annoInfo = jsonData.data;
+            var checksum = annoInfo.checksum;
+            updateAnnotationInfo(annotationPID, checksum);
+
             if(status == "success") {
                 alert("Successfully updated the annotation: " + JSON.stringify(annoInfo));
             } else if(status == "conflict"){
@@ -202,6 +205,18 @@ function updateAnnotation(annotationData) {
     });
 
 }
+
+// Update AnnotatoinDatastore
+function updateAnnotationInfo(pid, checksum) {
+    var annotations = anno.getAnnotations()
+    for(var j = 0; j < annotations.length; j++){
+        if(annotations[j].pid == pid) {
+            annotations[j].checksum = checksum;
+            break;
+        }
+    }
+}
+
 
 function deleteAnnotation(annotationData) {
     var annotationID = annotationData.pid;


### PR DESCRIPTION
## What does this PR do?

This PR is for https://github.com/digitalutsc/islandora_web_annotations/issues/15.  As per [Annotation protocol](https://www.w3.org/TR/annotation-protocol/), an ETag needs to be used to check if an item can be updated/deleted.  We use the checksum as the ETag.  If a datastream has been edited, a message will be displayed to user.  The operation will not be processed.  The user has the option to reload the annotations and retry the operation.

## How can I test it?
* Apply this PR
* Reload or create an image with annotations.  (Note the PID of the annotations).
* Load the annotations.  
* Edit an annotation.  It should display a success message.
* Before editing another annotation, go to the Fedora backend and modify the annotation datastream.  Ensure that Fedora has produced a new checksum.  For example, you can replace the datastream (https://raw.githubusercontent.com/Natkeeran/vanakkam/master/test.json).  Edit that annotation.  It should display a edit conflict message.
* Repeat the above steps for Delete operation.
