### PR TITLE
Basic image - some times annotations are not loading

### DIFF
--- a/css/basic_image/basic_image.css
+++ b/css/basic_image/basic_image.css
@@ -9,3 +9,8 @@
     left: 32px;
 }
 
+#add-annotation-button {
+    position:absolute;
+    top: 135px;
+    left:82px;
+}

--- a/js/basic_image/basic_image.js
+++ b/js/basic_image/basic_image.js
@@ -9,13 +9,24 @@ var g_contentType = "basic-image";
 
 jQuery(document).ready(function() {
 
-    var m_image = jQuery("div[class='islandora-basic-image-content']").find("img[typeof='foaf:Image']").first();
-    jQuery(m_image).unwrap();
-
     if(Drupal.settings.islandora_web_annotations.view == true) {
         var loadAnnotationsButton = jQuery('<button id="load-annotation-button" title="Load Annotations" class="annotator-adder-actions__button h-icon-annotate" onclick="getAnnotationsBasicImage()"></button>');
         loadAnnotationsButton.appendTo(jQuery(".islandora-basic-image-content")[0]);
     }
+
+    if(Drupal.settings.islandora_web_annotations.create == true) {
+        var addButton = jQuery('<button id="add-annotation-button" class="annotator-adder-actions__button h-icon-add" title="Add Annotation" onclick="initBasicImageAnnotation();"></button>');
+        addButton.appendTo(jQuery(".islandora-basic-image-content")[0]);
+    }
+
+    executeCommonLoadOperations();
+
+});
+
+
+function initBasicImageAnnotation(){
+    var m_image = jQuery("div[class='islandora-basic-image-content']").find("img[typeof='foaf:Image']").first();
+    jQuery(m_image).unwrap();
 
     anno.makeAnnotatable(m_image[0]);
 
@@ -37,15 +48,15 @@ jQuery(document).ready(function() {
         deleteAnnotation(annotation);
     });
 
+    jQuery("#add-annotation-button").remove();
     jQuery(".annotorious-hint").css("left", "45px");
 
-    executeCommonLoadOperations();
-
-
-});
-
+}
 
 function getAnnotationsBasicImage() {
+    if(jQuery(".annotorious-hint-icon").is(":visible")=== false) {
+        initBasicImageAnnotation();
+    }
     var objectPID = getBasicImagePID();
     getAnnotations(objectPID);
 }


### PR DESCRIPTION
## What does this PR do?
For basic image, the annotation feature was init on page load.  This most likely caused this issue: https://github.com/digitalutsc/islandora_web_annotations/issues/28.  In addition, loading on page load prevented the user from viewing the actual image, because the annotation was taking over the click method.  I added Add Annotation (+) similar to large image to init the annotations.  This seem to resolve the above issue.  

## How can I test it?
* Pull down the PR
* Go to basic image annotation
* Click the image, it should take you to the image
* Load annotations, it should load all annotations
* Click +, it should allow you to add annotations
* Reload page
* Click +, it should allow you to add annotations
* Load annotations, it should load all annotations

Please try to reproduce https://github.com/digitalutsc/islandora_web_annotations/issues/28.  This PR should address that issue as well.

