### PR TITLE
positioning issue in Chrome

### DIFF
--- a/js/large_image/large_image.js
+++ b/js/large_image/large_image.js
@@ -39,8 +39,12 @@ jQuery(document).ready(function() {
     var os_viewer = Drupal.settings.islandora_open_seadragon_viewer;
     anno.makeAnnotatable(os_viewer);
 
+    // This is a fix to address the annotation positioning (#6) related to issue in FireFox, not an issue in Chrome
     anno.addHandler('onEditorShown', function(annotation) {
-        window.pageYOffset = 0;
+        var isChrome = !!window.chrome;
+        if(!isChrome){
+            window.pageYOffset = 0;
+        }
     });
 
     anno.addHandler("onAnnotationCreated", function(annotation) {


### PR DESCRIPTION
## What is in this PR
This PR address an issue reported in Chrome related to https://github.com/digitalutsc/islandora_web_annotations/issues/6.  The workaround for that issue is not needed in Chrome.  On the contrary, it was causing a different similar issue.  We selectively apply the fix to FireFox.

## How to test it
* Get the PR
* Clear the cache in Chrome
* Create / Edit Annotations 
* Annotations position should be where you draw it, it should re position

