### PR TITLE
return other annotations, even if some annotation objects are not found

### DIFF
--- a/includes/AnnotationContainer.php
+++ b/includes/AnnotationContainer.php
@@ -76,8 +76,12 @@ class AnnotationContainer implements interfaceAnnotationContainer
             // Loop through each item and get the item info
             $newArray = array();
             for($i = 0; $i < count($items); $i++) {
-                $object = $this->repository->getObject($items[$i]);
-                $WADMObject = $object->getDatastream(AnnotationConstants::WADM_DSID);
+                try{
+                    $object = $this->repository->getObject($items[$i]);
+                    $WADMObject = $object->getDatastream(AnnotationConstants::WADM_DSID);
+                } catch(Exception $e){
+                    watchdog(AnnotationConstants::MODULE_NAME, 'AnnotationContainer : getAnnotationContainer: Unable to find annotation object with id ' . $items[$i]);
+                }
                 $dsContent = (string)$WADMObject->content;
                 $checksum = $WADMObject->checksum;
 

--- a/js/basic_image/basic_image.js
+++ b/js/basic_image/basic_image.js
@@ -65,6 +65,7 @@ function getBasicImagePID() {
     var objectURL = window.location.href;
     var objectPID = objectURL.substr(objectURL.lastIndexOf('/') + 1);
     objectPID = objectPID.replace("%3A", ":");
+    objectPID = objectPID.replace("#", "");
     return objectPID;
 }
 


### PR DESCRIPTION
# What does this Pull Request do?
This PR addresses this issue: https://github.com/digitalutsc/islandora_web_annotations/issues/57
Even if an annotation is not found (i.e deleted), we return the other annotations.  We have to determine if we want to remove it from the Annotation Container!

# How should this be tested?
* Fetch the PR
* Create number of annotations
* Delete on or more of the annotations from Fedora or from Drupal UI
* Reload the page and load the annotations, other annotations should show