### PR TITLE
Deletes annotationContainer when last annotation is deleted via UI.

### DIFF
--- a/includes/AnnotationContainer.php
+++ b/includes/AnnotationContainer.php
@@ -168,6 +168,12 @@ class AnnotationContainer implements interfaceAnnotationContainer
         $oAnnotation = new Annotation($this->repository);
         $oAnnotation->deleteAnnotation($annotationID);
 
+        // If there are no annotations, delete the annotationContainer
+        if (count($items) == 0) {
+          watchdog(AnnotationConstants::MODULE_NAME, 'AnnotationContainer: deleteAnnotation:  Zero annotations remaining, removing annotationContainer with id @annotationContainerID', array('@annotationContainerID'=>$annotationContainerID), WATCHDOG_INFO);
+          $this->deleteAnnotationContainer($annotationContainerID);
+        }
+
         // Return message
         $output = array('status' => "success", "data"=> "The following annotation was deleted: " . $annotationID);
         $output = json_encode($output);


### PR DESCRIPTION
# What does this Pull Request do?
Deletes the relevant annotationContainer when the last annotation is deleted via the annotation UI.

# What's new?
Adds a conditional to the deleteAnnotation method in the AnnotationContainer class.

# How should this be tested?
* Add annotations and delete.
* A watchdog log message is added when the annotationContainer is deleted, upon deletion of the last annotation via the non-admin UI.
* From the log message, grab the PID for the annotationConatiner and check that it is not available in Fedora commons directly.

# Additional Notes:
Does not delete the annotationContainer when deleting annotations via the object manage UI.  See the related issue https://github.com/digitalutsc/islandora_web_annotations/issues/57.

