### PR TITLE
convert getAnnotations into a toggle button

### DIFF
--- a/js/base/base.js
+++ b/js/base/base.js
@@ -8,6 +8,7 @@
 
 var annotationContainerID = null;
 var label_prefix = "label_anno";
+var b_annotationsShown = false;
 
 function executeCommonLoadOperations() {
     // Apply permissions to edit, delete annotations
@@ -77,6 +78,14 @@ function updateNewAnnotationInfo(pid, creator, created, checksum) {
 }
 
 function getAnnotations(targetObjectId) {
+    // getAnnotations is converted to a Toggle - issue#70
+    if(b_annotationsShown == true) {
+        anno.removeAll();
+        deleteAllLabelsAndBlockItems();
+        b_annotationsShown = false;
+        return;
+    }
+
     var annotation = {
         targetPid: targetObjectId
     };
@@ -147,6 +156,7 @@ function getAnnotations(targetObjectId) {
             insertUpdateAnnotationDataBlock(htmlBlock);
         }
     });
+    b_annotationsShown = true;
 }
 
 function updateAnnotation(annotationData) {


### PR DESCRIPTION
# What does this Pull Request do?
Addresses this issue: https://github.com/digitalutsc/islandora_web_annotations/issues/70

# How should this be tested?
* Go to a basic image/large image/paged content object
* click the load annotations button - it should show
* click again - it should hide
* click again - it should show
