### PR TITLE
Add anno list to Paged Content

### DIFF
--- a/js/base/base.js
+++ b/js/base/base.js
@@ -285,7 +285,7 @@ function deleteAnnotation(annotationData) {
 function insertUpdateAnnotationDataBlock(htmlBlock) {
     // If not already installed
     if(jQuery("#annotation-list").length == 0) {
-        jQuery('<div><h2>Annotations</h2><ul id="annotation-list" style="list-style-type: none;">' + htmlBlock + '</ul></div>').appendTo(jQuery(".islandora-" + g_contentType + "-metadata"));
+        jQuery('<div><h2>Annotations</h2><ul id="annotation-list" style="list-style-type: none;">' + htmlBlock + '</ul></div>').appendTo(jQuery("#block-system-main"));
     } else {
         jQuery(htmlBlock).appendTo(jQuery("#annotation-list"));
     }


### PR DESCRIPTION
# What does this Pull Request do?
Annotations list was missing in the Paged Content, because of an incorrect DOM element targeting.  This PR addresses this issue.

# How should this be tested?
* Go to a Paged Content object
* Load the annotations
* The annotations list should show
* Repeat the above steps for Basic Image and Large Image
