### PR TITLE
Admin form base

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @file
+ * Handles the display/submission of the admin settings form for this module.
+ */
+
+/**
+ * Defines the admin settings form.
+ *
+ * @param array $form
+ *   The Drupal form definition.
+ * @param array $form_state
+ *   The Drupal form state.
+ *
+ * @return array
+ *   The Drupal form definition.
+ */
+function islandora_web_annotations_admin(array $form, array &$form_state) {
+  module_load_include('inc', 'islandora', 'includes/solution_packs');
+  $form = array();
+  $form['islandora_web_annotations_verbose'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Verbose Alert Messages'),
+      '#description' => t('Provides verbose (alert) messages, useful when testing, debuging and developing.'),
+      '#default_value' => variable_get('islandora_web_annotations_verbose', FALSE),
+  );
+
+  $form['actions'] = array('#type' => 'actions');
+  $form['actions']['reset'] = array(
+      '#type' => 'submit',
+      '#value' => t('Reset to defaults'),
+      '#weight' => 1,
+      '#submit' => array('islandora_web_annotations_admin_reset'),
+  );
+
+  $form = system_settings_form($form);
+  return $form;
+
+}
+
+/**
+ * Form reset for allowing the deletion of the viewer variable.
+ */
+function islandora_web_annotations_admin_reset($form, &$form_state)
+{
+  $op = $form_state['clicked_button']['#id'];
+  switch ($op) {
+    case 'edit-reset':
+      variable_del('islandora_web_annotations_verbose');
+      break;
+  }
+}

--- a/islandora_web_annotations.install
+++ b/islandora_web_annotations.install
@@ -13,6 +13,8 @@
 
 function islandora_web_annotations_install() {
     module_load_include('inc', 'islandora', 'includes/solution_packs');
+    // Set variable defaults
+    variable_set('islandora_web_annotations_verbose', FALSE)
     islandora_install_solution_pack('islandora_web_annotations');
 }
 
@@ -21,5 +23,9 @@ function islandora_web_annotations_install() {
  */
 function islandora_web_annotations_uninstall() {
     module_load_include('inc', 'islandora', 'includes/solution_packs');
+    $variables = array(
+      'islandora_web_annotations_verbose',
+    );
+    array_map('variable_del', $variables);
     islandora_install_solution_pack('islandora_web_annotations', 'uninstall');
 }

--- a/islandora_web_annotations.install
+++ b/islandora_web_annotations.install
@@ -14,7 +14,7 @@
 function islandora_web_annotations_install() {
     module_load_include('inc', 'islandora', 'includes/solution_packs');
     // Set variable defaults
-    variable_set('islandora_web_annotations_verbose', FALSE)
+    variable_set('islandora_web_annotations_verbose', FALSE);
     islandora_install_solution_pack('islandora_web_annotations');
 }
 

--- a/islandora_web_annotations.module
+++ b/islandora_web_annotations.module
@@ -68,6 +68,16 @@ function islandora_web_annotations_menu() {
         'type' => MENU_CALLBACK,
     );
 
+    $items['admin/islandora/web_annotations'] = array(
+        'title' => 'Web Annotations',
+        'description' => 'Web Annotation related configuraiton options',
+        'page callback' => 'drupal_get_form',
+        'page arguments' => array('islandora_web_annotations_admin'),
+        'access arguments' => array('administer site configuration'),
+        'file' => 'includes/admin.form.inc',
+        'type' => MENU_NORMAL_ITEM,
+    );
+
     return $items;
 }
 


### PR DESCRIPTION
# What does this Pull Request do?
Adds a base admin menu for web annotation related configuration options.  Adds verbose option for messages (not yet implemented when generating alerts).  Also updated the install file to add and delete the variable for the verbose messages option.

# What's new?
Admin form under Islandora for Web Annotations.  Variable for flagging verbose messaging in alerts and elsewhere as the need arises.

# How should this be tested?
Pull the files and verify that you see the admin form when you navigate to Admin > Islandora > Web Annotations.  You should see a basic form with a checkbox for the verbose messaging.

# Additional Notes:
* Related to issues https://github.com/digitalutsc/islandora_web_annotations/issues/67 and https://github.com/digitalutsc/islandora_web_annotations/issues/66
* Documentation will need to be created for any admin configuration options created.