### PR TITLE
Issue 66

### DIFF
--- a/islandora_web_annotations.module
+++ b/islandora_web_annotations.module
@@ -131,7 +131,9 @@ function islandora_web_annotations_init() {
     $edit_own = user_access(ISLANDORA_WEB_ANNOTATION_EDIT_OWN);
     $delete_own = user_access(ISLANDORA_WEB_ANNOTATION_DELETE_OWN);
 
-    drupal_add_js(array('islandora_web_annotations' => array('user'=>$username, 'view' => $view, 'create'=>$create, 'edit_any'=>$edit_any, 'delete_any'=>$delete_any, 'edit_own'=>$edit_own, 'delete_own'=>$delete_own)), array('type' => 'setting'));
+    $verbose_messages = variable_get('islandora_web_annotations_verbose', FALSE);
+
+    drupal_add_js(array('islandora_web_annotations' => array('user'=>$username, 'view' => $view, 'create'=>$create, 'edit_any'=>$edit_any, 'delete_any'=>$delete_any, 'edit_own'=>$edit_own, 'delete_own'=>$delete_own, 'verbose_messages' =>$verbose_messages)), array('type' => 'setting'));
 }
 
 

--- a/js/base/base.js
+++ b/js/base/base.js
@@ -45,7 +45,6 @@ function createAnnotation(targetObjectId, annotationData) {
         type: 'POST',
         data: annotation,
         error: function() {
-            //alert("Error in creating annotation.");
             var msg = "Error in creating annotation.";
             verbose_alert(msg, msg);
         },
@@ -58,9 +57,8 @@ function createAnnotation(targetObjectId, annotationData) {
 
             updateNewAnnotationInfo(pid, creator, created, checksum);
             insertLabelForNewAnnotation(pid, annotationData);
-            //alert("Successfully created annotation: " + data);
-            var verbose_message = "Successfully created annotation: " + data;
-            var short_message = "Successfully created annotation.";
+            var verbose_message = "Annotation successfully created: " + data;
+            var short_message = "Annotation successfully created.";
             verbose_alert(short_message, verbose_message);
         }
     });
@@ -100,7 +98,6 @@ function getAnnotations(targetObjectId) {
         type: 'GET',
         data: annotation,
         error: function() {
-            //alert("Error in loading annotations");
             var msg = "Error in loading annotations";
             verbose_alert(msg, msg);
         },
@@ -154,7 +151,6 @@ function getAnnotations(targetObjectId) {
                     };
                     anno.addAnnotation(myAnnotation);
                 } catch(e){
-                    //alert("Error in inserting an annotation");
                     var msg = "Error in inserting an annotation";
                     verbose_alert(msg, msg);
                 }
@@ -205,7 +201,6 @@ function updateAnnotation(annotationData) {
         type: 'PUT',
         data: annotation,
         error: function() {
-            //alert("Error in updating annotation.");
             var msg = "Error in updating annotation.";
             verbose_alert(msg, msg);
 
@@ -219,17 +214,13 @@ function updateAnnotation(annotationData) {
             updateAnnotationInfo(annotationPID, checksum, updatedText);
 
             if(status == "success") {
-                //alert("Successfully updated the annotation: " + JSON.stringify(annoInfo));
                 var verbose_message = "Successfully updated the annotation: " + JSON.stringify(annoInfo);
                 var short_message = "Update successful.";
                 verbose_alert(short_message, verbose_message);
-
             } else if(status == "conflict"){
-                //alert("There was an edit conflict.  Please copy your changes, reload the annotations and try again");
                 var msg = "There was an edit conflict.  Please copy your changes, reload the annotations and try again";
                 verbose_alert(msg, msg);
             } else {
-                //alert("Unable to update.  Error info: " . JSON.stringify(annoInfo));
                 var verbose_message = "Unable to update.  Error info: " . JSON.stringify(annoInfo);
                 var short_message = "Error: Unable to update.";
                 verbose_alert(short_massage, verbose_message);
@@ -278,7 +269,7 @@ function deleteAnnotation(annotationData) {
         type: 'DELETE',
         data: annotation,
         error: function() {
-            //alert("Error in deleting annotation.");
+
             var msg = "Error in deleting annotation.";
             verbose_alert(msg, msg);
 
@@ -288,16 +279,13 @@ function deleteAnnotation(annotationData) {
             var status = jsonData.status;
             var annoInfo = jsonData.data;
             if(status == "success") {
-                //alert("Success: " + JSON.stringify(annoInfo));
                 var verbose_message = "Success: " + JSON.stringify(annoInfo);
                 var short_message = "Success:  Annotation deleted.";
                 verbose_alert(short_message, verbose_message);
             } else if(status == "conflict"){
-                //alert("There was an edit conflict.  Please reload the annotations to view the changes.  You can try again to delete.");
                 var msg = "There was an edit conflict.  Please reload the annotations to view the changes.  You can try again to delete.";
                 verbose_alert(msg, msg);
             } else {
-                //alert("Unable to delete.  Error info: " . JSON.stringify(annoInfo));
                 var verbose_message = "Unable to delete.  Error info: " . JSON.stringify(annoInfo);
                 var short_message = "Error: Unable to delete.";
                 verbose_alert(short_message, verbose_message);

--- a/js/base/base.js
+++ b/js/base/base.js
@@ -45,7 +45,9 @@ function createAnnotation(targetObjectId, annotationData) {
         type: 'POST',
         data: annotation,
         error: function() {
-            alert("Error in creating annotation.");
+            //alert("Error in creating annotation.");
+            var msg = "Error in creating annotation.";
+            verbose_alert(msg, msg);
         },
         success: function(data) {
             var jsonData = JSON.parse(data);
@@ -56,7 +58,10 @@ function createAnnotation(targetObjectId, annotationData) {
 
             updateNewAnnotationInfo(pid, creator, created, checksum);
             insertLabelForNewAnnotation(pid, annotationData);
-            alert("Successfully created annotation: " + data);
+            //alert("Successfully created annotation: " + data);
+            var verbose_msg = "Successfully created annotation: " + data;
+            var shor_msg = "Successfully created annotation.";
+            verbose_alert("Successfully created annotation: " + data);
         }
     });
 
@@ -95,7 +100,9 @@ function getAnnotations(targetObjectId) {
         type: 'GET',
         data: annotation,
         error: function() {
-            alert("Error in loading annotations");
+            //alert("Error in loading annotations");
+            var msg = "Error in loading annotations";
+            verbose_alert(msg, msg);
         },
         success: function(data) {
 
@@ -147,7 +154,9 @@ function getAnnotations(targetObjectId) {
                     };
                     anno.addAnnotation(myAnnotation);
                 } catch(e){
-                    alert("Error in inserting an annotation");
+                    //alert("Error in inserting an annotation");
+                    var msg = "Error in inserting an annotation";
+                    verbose_alert(msg, msg);
                 }
                 insertLabel(g_contentType, i+1, pid, canvas, x1, y1, width1, height1);
             }
@@ -196,7 +205,10 @@ function updateAnnotation(annotationData) {
         type: 'PUT',
         data: annotation,
         error: function() {
-            alert("Error in updating annotation.");
+            //alert("Error in updating annotation.");
+            var msg = "Error in updating annotation.";
+            verbose_alert(msg, msg);
+
         },
         success: function(data) {
             var jsonData = JSON.parse(data);
@@ -207,11 +219,20 @@ function updateAnnotation(annotationData) {
             updateAnnotationInfo(annotationPID, checksum, updatedText);
 
             if(status == "success") {
-                alert("Successfully updated the annotation: " + JSON.stringify(annoInfo));
+                //alert("Successfully updated the annotation: " + JSON.stringify(annoInfo));
+                var verbose_message = "Successfully updated the annotation: " + JSON.stringify(annoInfo);
+                var short_message = "Update successful.";
+                verbose_alert(short_message, verbose_message);
+
             } else if(status == "conflict"){
-                alert("There was an edit conflict.  Please copy your changes, reload the annotations and try again");
+                //alert("There was an edit conflict.  Please copy your changes, reload the annotations and try again");
+                var msg = "There was an edit conflict.  Please copy your changes, reload the annotations and try again";
+                verbose_alert(msg, msg);
             } else {
-                alert("Unable to update.  Error info: " . JSON.stringify(annoInfo));
+                //alert("Unable to update.  Error info: " . JSON.stringify(annoInfo));
+                var verbose_message = "Unable to update.  Error info: " . JSON.stringify(annoInfo);
+                var short_message = "Error: Unable to update.";
+                verbose_alert(short_massage, verbose_message);
             }
         }
     });
@@ -257,25 +278,35 @@ function deleteAnnotation(annotationData) {
         type: 'DELETE',
         data: annotation,
         error: function() {
-            alert("Error in deleting annotation.");
+            //alert("Error in deleting annotation.");
+            var msg = "Error in deleting annotation.";
+            verbose_alert(msg, msg);
+
         },
         success: function(data) {
             var jsonData = JSON.parse(data);
             var status = jsonData.status;
             var annoInfo = jsonData.data;
             if(status == "success") {
-                alert("Success: " + JSON.stringify(annoInfo));
+                //alert("Success: " + JSON.stringify(annoInfo));
+                var verbose_message = "Success: " + JSON.stringify(annoInfo);
+                var short_message = "Success:  Annotation deleted.";
+                verbose_alert(short_message, verbose_message);
             } else if(status == "conflict"){
-                alert("There was an edit conflict.  Please reload the annotations to view the changes.  You can try again to delete.");
+                //alert("There was an edit conflict.  Please reload the annotations to view the changes.  You can try again to delete.");
+                var msg = "There was an edit conflict.  Please reload the annotations to view the changes.  You can try again to delete.";
+                verbose_alert(msg, msg);
             } else {
-                alert("Unable to delete.  Error info: " . JSON.stringify(annoInfo));
+                //alert("Unable to delete.  Error info: " . JSON.stringify(annoInfo));
+                var verbose_message = "Unable to delete.  Error info: " . JSON.stringify(annoInfo);
+                var short_message = "Error: Unable to delete.";
+                verbose_alert(short_message, verbose_message);
             }
         }
     });
 
     deleteLabelAndDataBlockItem(annotationID);
 }
-
 
 /**
  *
@@ -374,4 +405,13 @@ function deleteAllLabelsAndBlockItems(){
     }
 
     jQuery("#annotation-list").parent().remove();
+}
+
+function verbose_alert(short_message, verbose_message) {
+    var verbose_flag = Drupal.settings.islandora_web_annotations.verbose_messages;
+    if(verbose_flag){
+        alert(verbose_message);
+    } else {
+        alert(short_message);
+    }
 }

--- a/js/base/base.js
+++ b/js/base/base.js
@@ -59,9 +59,9 @@ function createAnnotation(targetObjectId, annotationData) {
             updateNewAnnotationInfo(pid, creator, created, checksum);
             insertLabelForNewAnnotation(pid, annotationData);
             //alert("Successfully created annotation: " + data);
-            var verbose_msg = "Successfully created annotation: " + data;
-            var shor_msg = "Successfully created annotation.";
-            verbose_alert("Successfully created annotation: " + data);
+            var verbose_message = "Successfully created annotation: " + data;
+            var short_message = "Successfully created annotation.";
+            verbose_alert(short_message, verbose_message);
         }
     });
 

--- a/js/basic_image/basic_image.js
+++ b/js/basic_image/basic_image.js
@@ -36,7 +36,8 @@ function initBasicImageAnnotation(){
             annotation.pid = "New";
             createAnnotation(objectPID, annotation);
         } else {
-            alert("You do not have permissions to save annotations for basic image.");
+            var msg = "You do not have permissions to save annotations for basic image.";
+            verbose_alert(msg, msg);
         }
     });
 


### PR DESCRIPTION
# What does this Pull Request do?
Adds the verbose_alert JS function in base.js and updates the alert messages to provide short and verbose messages as appropriate based on the web annotation admin setting.  Addresses issue https://github.com/digitalutsc/islandora_web_annotations/issues/66.

# What's new?
Adds verbose_alert JS function.  Provides short messages where previously there were only verbose messages in alerts.

# How should this be tested?
Check and uncheck the verbose messages admin option for Web Annotations.  Alert messages that previously provided detailed output should now provide a short message should verbose messaging be unchecked.

# Additional Notes:
Going forward, use `verbose_alert` instead of `alert` for alert messages.   For alerts where only a short message makes sense, still use `verbose_alert` for consistency and should a more detailed message option become necessary later.


