### PR TITLE
change hook so content models don't get installed each time

### DIFF
--- a/islandora_web_annotations.module
+++ b/islandora_web_annotations.module
@@ -165,7 +165,7 @@ function islandora_web_annotations_islandora_required_objects(IslandoraTuque $co
  * @param array $context
  */
 
-function islandora_web_annotations_islandora_object_alter(AbstractObject $object, array &$context) {
+function islandora_web_annotations_islandora_solution_pack(AbstractObject $object, array &$context) {
     // If delete action
     if($context["action"] == "purge"){
         $object_content_models = $object->relationships->get('info:fedora/fedora-system:def/model#', 'hasModel');


### PR DESCRIPTION
# What does this Pull Request do?
Change the installation of required object to install hook instead of required objects hook.  Because required objects hook was firing on each ingest.

# How should this be tested?
1. Apply the PR.  Do a fresh install.  Verify that required objects (WADM and WADMContainer data models) get installed.  
2. Verify that user is able to create/edit/delete annotations.  
