### PR TITLE
import web annotation block view

### DIFF
--- a/includes/views/islandora_web_annotations.views_default.inc
+++ b/includes/views/islandora_web_annotations.views_default.inc
@@ -60,7 +60,7 @@ $handler->display->display_options['arguments']['annotation_parent']['summary_op
 /* Display: Block */
 $handler = $view->new_display('block', 'Block', 'block_1');
 
-$views['usage_collection'] = $view;
+$views['islandora_web_annotations'] = $view;
 
   return $views;
 }

--- a/islandora_web_annotations.module
+++ b/islandora_web_annotations.module
@@ -138,7 +138,7 @@ function islandora_web_annotations_permission() {
 function islandora_web_annotations_views_api() {
   return array(
     'api' => 3,
-    'path' => drupal_get_path('module', 'islandora_web_annotations') . 'includes/views',
+    'path' => drupal_get_path('module', 'islandora_web_annotations') . '/includes/views',
   );
 }
 

--- a/islandora_web_annotations.module
+++ b/islandora_web_annotations.module
@@ -131,6 +131,17 @@ function islandora_web_annotations_permission() {
     );
 }
 
+
+/**
+ * Implements hook_views_api().
+ */
+function islandora_web_annotations_views_api() {
+  return array(
+    'api' => 3,
+    'path' => drupal_get_path('module', 'islandora_web_annotations') . '/views',
+  );
+}
+
 /**
  * Send user access related information to js for access control
  */

--- a/islandora_web_annotations.module
+++ b/islandora_web_annotations.module
@@ -138,7 +138,7 @@ function islandora_web_annotations_permission() {
 function islandora_web_annotations_views_api() {
   return array(
     'api' => 3,
-    'path' => drupal_get_path('module', 'islandora_web_annotations') . '/views',
+    'path' => drupal_get_path('module', 'islandora_web_annotations') . 'includes/views',
   );
 }
 

--- a/views/islandora_web_annotations.views_default.inc
+++ b/views/islandora_web_annotations.views_default.inc
@@ -60,7 +60,7 @@ $handler->display->display_options['arguments']['annotation_parent']['summary_op
 /* Display: Block */
 $handler = $view->new_display('block', 'Block', 'block_1');
 
-$views['usage_collection'] = $view;
+$views['islandora_web_annotations'] = $view;
 
   return $views;
 }

--- a/views/islandora_web_annotations.views_default.inc
+++ b/views/islandora_web_annotations.views_default.inc
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @file
+ * Default views.
+ */
+
+/**
+ * Implements hook_views_default_views().
+ */
+function islandora_web_annotations_views_default_views() {
+
+$view = new view();
+$view->name = 'islandora_web_annotations';
+$view->description = '';
+$view->tag = 'default';
+$view->base_table = 'islandora_solr';
+$view->human_name = 'Islandora Web Annotation Block';
+$view->core = 7;
+$view->api_version = '3.0';
+$view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+/* Display: Master */
+$handler = $view->new_display('default', 'Master', 'default');
+$handler->display->display_options['title'] = 'Islandora Web Annotation Block';
+$handler->display->display_options['use_more_always'] = FALSE;
+$handler->display->display_options['access']['type'] = 'none';
+$handler->display->display_options['cache']['type'] = 'none';
+$handler->display->display_options['query']['type'] = 'views_query';
+$handler->display->display_options['exposed_form']['type'] = 'basic';
+$handler->display->display_options['pager']['type'] = 'full';
+$handler->display->display_options['pager']['options']['items_per_page'] = '100';
+$handler->display->display_options['pager']['options']['offset'] = '0';
+$handler->display->display_options['pager']['options']['id'] = '0';
+$handler->display->display_options['pager']['options']['quantity'] = '9';
+$handler->display->display_options['style_plugin'] = 'list';
+$handler->display->display_options['style_options']['type'] = 'ol';
+$handler->display->display_options['row_plugin'] = 'fields';
+/* Field: Islandora Solr: annotation_value */
+$handler->display->display_options['fields']['annotation_value']['id'] = 'annotation_value';
+$handler->display->display_options['fields']['annotation_value']['table'] = 'islandora_solr';
+$handler->display->display_options['fields']['annotation_value']['field'] = 'annotation_value';
+$handler->display->display_options['fields']['annotation_value']['label'] = '';
+$handler->display->display_options['fields']['annotation_value']['element_label_colon'] = FALSE;
+$handler->display->display_options['fields']['annotation_value']['link_to_object'] = 0;
+/* Sort criterion: Islandora Solr: fgs_createdDate_dt */
+$handler->display->display_options['sorts']['fgs_createdDate_dt']['id'] = 'fgs_createdDate_dt';
+$handler->display->display_options['sorts']['fgs_createdDate_dt']['table'] = 'islandora_solr';
+$handler->display->display_options['sorts']['fgs_createdDate_dt']['field'] = 'fgs_createdDate_dt';
+/* Contextual filter: Islandora Solr: annotation_parent */
+$handler->display->display_options['arguments']['annotation_parent']['id'] = 'annotation_parent';
+$handler->display->display_options['arguments']['annotation_parent']['table'] = 'islandora_solr';
+$handler->display->display_options['arguments']['annotation_parent']['field'] = 'annotation_parent';
+$handler->display->display_options['arguments']['annotation_parent']['default_action'] = 'default';
+$handler->display->display_options['arguments']['annotation_parent']['default_argument_type'] = 'raw';
+$handler->display->display_options['arguments']['annotation_parent']['default_argument_options']['index'] = '2';
+$handler->display->display_options['arguments']['annotation_parent']['summary']['number_of_records'] = '0';
+$handler->display->display_options['arguments']['annotation_parent']['summary']['format'] = 'default_summary';
+$handler->display->display_options['arguments']['annotation_parent']['summary_options']['items_per_page'] = '25';
+
+/* Display: Block */
+$handler = $view->new_display('block', 'Block', 'block_1');
+
+$views['usage_collection'] = $view;
+
+  return $views;
+}
+


### PR DESCRIPTION
# What does this Pull Request do?
Import a Solr View Block to display annotations. Works for any islandora object that is identified as an 'annotation parent'.

# What's new?
- new views/ directory with one view
- use of hook_views_api() in .module

it's been a long time since i touched code, please feel free to give feedback.

# How should this be tested?
* Install module
* Check that a new view is installed when you go to Structure > Views
* Check in Structure > Blocks that you can see "View: Islandora Web Annotation Block"

# Additional Notes:
* no known impacts to other code. Could redesign block in the future if it does not render RTF text properly.