### PR TITLE
Make large image label constant size

### DIFF
--- a/css/base/base.css
+++ b/css/base/base.css
@@ -80,7 +80,10 @@ span.marker-large-mage {
     text-align: center;
     position: absolute;
     vertical-align: middle;
+    line-height: 20px;
     cursor: pointer;
+    width: 20px;
+    height: 20px;
 }
 
 

--- a/js/base/base.js
+++ b/js/base/base.js
@@ -350,10 +350,16 @@ function insertLabel(contentType, i, pid, canvas, x1, y1, width1, height1) {
         eleSpan.className = "marker-large-mage";
         eleSpan.setAttribute("id", label_prefix + pid);
 
+        var imagePoint = Drupal.settings.islandora_open_seadragon_viewer.viewport.viewportToImageCoordinates(decimalX, decimalY);
+
         Drupal.settings.islandora_open_seadragon_viewer.addOverlay({
             element: eleSpan,
-            location: new OpenSeadragon.Rect(decimalX - 0.035, decimalY - 0.035, 0.035, 0.035)
+            px: imagePoint.x,
+            py: imagePoint.y,
+            checkResize: false,
+            placement: OpenSeadragon.OverlayPlacement.BOTTOM_RIGHT
         });
+
     } else {
         var canvasWidth = canvas.width;
         var canvasHeight = canvas.height;


### PR DESCRIPTION
# What does this Pull Request do?
This PR addresses the following three issues related to labelling annotations for large images (openseadragon):
* https://github.com/digitalutsc/islandora_web_annotations/issues/71 - labels scale to obstruct the subject area - Label size is made to be constant.  Thus when zooming in, the label size is smaller or remains constant compared to the subject area.  

* https://github.com/digitalutsc/islandora_web_annotations/issues/68 - The number and label box are held constant.  Which makes it readable.  

* https://github.com/digitalutsc/islandora_web_annotations/issues/67 - Though this does not address the issues directly.  It address this issue by making it readable even at higher zoom levels.

# How should this be tested?
* Get latest
* Go to large image, load annotations - annotation labels should have constant size
* Create annotations - annotation labels should have constant size


