### PR TITLE
Issue 30

### DIFF
--- a/includes/Annotation.php
+++ b/includes/Annotation.php
@@ -24,9 +24,9 @@ class Annotation implements interfaceAnnotation
     }
 
     public function createAnnotation($annotationContainerID, $annotationData, $annotationMetadata){
-
+        $annotation_namespace = variable_get('islandora_web_annotations_namespace', 'annotation');
         try {
-            $object = $this->repository->constructObject("annotation");
+            $object = $this->repository->constructObject($annotation_namespace);
 
             $target = $annotationData["context"];
             $target = str_replace("%3A",":",$target);

--- a/includes/AnnotationContainer.php
+++ b/includes/AnnotationContainer.php
@@ -26,10 +26,10 @@ class AnnotationContainer implements interfaceAnnotationContainer
      * @return none
      */
     public function createAnnotationContainer($targetObjectID, $annotationData){
-
+      $annotation_namespace = variable_get('islandora_web_annotations_namespace', 'annotation');
         try {
             $target = $annotationData["context"];
-            $object = $this->repository->constructObject("annotation");
+            $object = $this->repository->constructObject($annotation_namespace);
             $object->label = "AnnotationContainer for " . $targetObjectID;
             $object->models = array(AnnotationConstants::WADMContainer_CONTENT_MODEL);
             $object->relationships->add(FEDORA_RELS_EXT_URI, 'isMemberOfCollection', AnnotationConstants::WADMContainer_CONTENT_MODEL);

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -25,7 +25,12 @@ function islandora_web_annotations_admin(array $form, array &$form_state) {
       '#description' => t('Provides verbose (alert) messages, useful when testing, debuging and developing.'),
       '#default_value' => variable_get('islandora_web_annotations_verbose', FALSE),
   );
-
+  $form['islandora_web_annotations_namespace'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Annotation Namespace'),
+      '#description' => t('Sets the namespace to use for annotation objects.  Defaults to \'annotation.\''),
+      '#default_value' => variable_get('islandora_web_annotations_namespace', 'annotation'),
+  );
   $form['actions'] = array('#type' => 'actions');
   $form['actions']['reset'] = array(
       '#type' => 'submit',

--- a/islandora_web_annotations.module
+++ b/islandora_web_annotations.module
@@ -68,7 +68,7 @@ function islandora_web_annotations_menu() {
         'type' => MENU_CALLBACK,
     );
 
-    $items['admin/islandora/web_annotations'] = array(
+    $items['admin/islandora/tools/web_annotations'] = array(
         'title' => 'Web Annotations',
         'description' => 'Web Annotation related configuration options',
         'page callback' => 'drupal_get_form',


### PR DESCRIPTION
# What does this Pull Request do?
* Addresses bullet three of issue https://github.com/digitalutsc/islandora_web_annotations/issues/30.
* Adds the ability to set the namespace for Web Annotations (annotationContainer and annotation objects) via the Web Annotations administration form.   Defaults to 'annotation'.
* Moves the admin link to Web Annotation into the Islandora Utility modules menu.

# What's new?
Ability to set a custom namespace for annotation objects.
Moves the admin link to the Web Annotation admin form into the Islandora Utility modules menu.

# How should this be tested?
* Change the namespace for annotations in the Web Annotations admin form.
* Create annotations and confirm that the namespace is used when viewing the object in Fedora Commons.
* Try changing the namespace between creating multiple annotations on an object.  Check if this causes any unexpected behaviour.

# Additional Notes:
* Not covered in this pull-request is the issue that annotation namespaces are not dealt with via the  Enforce namespace restrictions Islandora configuration.
* Documentation should be created regarding setting namespaces for annotations and potential use-cases of this feature.
