### PR TITLE
Allows admin to configure the isAnnotationContainerOf Solr field

### DIFF
--- a/includes/AnnotationContainer.php
+++ b/includes/AnnotationContainer.php
@@ -242,8 +242,8 @@ class AnnotationContainer implements interfaceAnnotationContainer
     public function getAnnotationContainerPID($objectPID)
     {
         $url = parse_url(variable_get('islandora_solr_url', 'localhost:8080/solr'));
-
-        $qualifier = 'RELS_EXT_isAnnotationContainerOf_uri_s:' . '"' . "info:fedora/" . $objectPID . '"';
+        $isAnnotationContainerOfSolrField = variable_get('islandora_web_annotations_isannotationcontainerof_solr_field', 'RELS_EXT_isAnnotationContainerOf_uri_s');
+        $qualifier = $isAnnotationContainerOfSolrField . ':' . '"' . "info:fedora/" . $objectPID . '"';
         $query = "$qualifier";
         $fields = array('PID');
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -31,6 +31,13 @@ function islandora_web_annotations_admin(array $form, array &$form_state) {
       '#description' => t('Sets the namespace to use for annotation objects.  Defaults to \'annotation.\''),
       '#default_value' => variable_get('islandora_web_annotations_namespace', 'annotation'),
   );
+  $form['islandora_web_annotations_isannotationcontainerof_solr_field'] = array(
+      '#type' => 'textfield',
+      '#title' => t('The isAnnotationContainerOf Solr field'),
+      '#required' => TRUE,
+      '#description' => t('Sets the Solr field containing an object\'s isAnnotationContainerOf relationship.'),
+      '#default_value' => variable_get('islandora_web_annotations_isannotationcontainerof_solr_field', 'RELS_EXT_isAnnotationContainerOf_uri_s'),
+  );
   $form['actions'] = array('#type' => 'actions');
   $form['actions']['reset'] = array(
       '#type' => 'submit',


### PR DESCRIPTION
# What does this Pull Request do?
Allows admin to configure the isAnnotationContainerOf Solr field via the Islandora Web Annotation admin settings form.

# How should this be tested?
* Test to make sure that the form value is saved when modified.
* Test that you're still able to load previously created annotations (which used the default value of `RELS_EXT_isAnnotationContainerOf_uri_s`).
* Try modifying your Solr configuration to use a different value, for example, so that it uses `RELS_EXT_isAnnotationContainerOf_uri_ms`.

# Additional Notes:
* Documentation of this configuration setting will be needed.
* Changing the isAnnotationContainerOf Solr field when there are existing annotations may require reindexing of the annotations and related annotation containers in Solr.

