### PR TITLE
Adds configuration option to load annotations by default for large images.

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -31,6 +31,12 @@ function islandora_web_annotations_admin(array $form, array &$form_state) {
       '#description' => t('When checked, the default list of annotations is hidden.  This will allow you to use a Solr view block instead.'),
       '#default_value' => variable_get('islandora_web_annotations_hide_list_block', FALSE),
   );
+  $form['islandora_web_annotations_load_true'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Load annotations by default for large images.'),
+      '#description' => t('When checked, annotations will be loaded by default for large images.  You will still be able to toggle annotations (view, hide).'),
+      '#default_value' => variable_get('islandora_web_annotations_load_true', FALSE),
+  );
   $form['islandora_web_annotations_namespace'] = array(
       '#type' => 'textfield',
       '#title' => t('Annotation Namespace'),

--- a/islandora_web_annotations.module
+++ b/islandora_web_annotations.module
@@ -162,7 +162,7 @@ function islandora_web_annotations_init() {
 
     $verbose_messages = variable_get('islandora_web_annotations_verbose', FALSE);
     $hide_list_block = variable_get('islandora_web_annotations_hide_list_block', FALSE);
-
+    $load_true = variable_get('islandora_web_annotations_load_true', FALSE);
     drupal_add_js(array('islandora_web_annotations' =>
                           array('user'=>$username,
                             'view' => $view,
@@ -172,7 +172,8 @@ function islandora_web_annotations_init() {
                             'edit_own'=>$edit_own,
                             'delete_own'=>$delete_own,
                             'verbose_messages' =>$verbose_messages,
-                            'hide_list_block' => $hide_list_block
+                            'hide_list_block' => $hide_list_block,
+                            'load_true' => $load_true
                           )
                         ), array('type' => 'setting')
                   );

--- a/js/large_image/large_image.js
+++ b/js/large_image/large_image.js
@@ -28,6 +28,10 @@ jQuery(document).ready(function() {
     if(Drupal.settings.islandora_web_annotations.view == true) {
         var saveButton = jQuery('<button id="load-annotation-button" title="Load Annotations" class="annotator-adder-actions__button h-icon-annotate" onclick="getAnnotationsLargeImage()"></button>');
         saveButton.appendTo(jQuery("#openseadragon-wrapper"));
+
+        if(Drupal.settings.islandora_web_annotations.load_true == true){
+            getAnnotationsLargeImage();
+        }
     }
 
     if(Drupal.settings.islandora_web_annotations.create == true) {


### PR DESCRIPTION
# What does this Pull Request do?
Adds a configuration options (as a checkbox) to load annotations by default for large images.  Partially addresses issue #107.

# How should this be tested?
Test that the configuration option is respected for large images.
* When checked, the annotations are loaded by default when viewing a large image object.
* When unchecked, the annotations do not load by default, you need to click the load annotations buttons to view annotations.

# Additional Notes:
This pull-request partially addresses issue #107.  There are still some things that need to be resolved to address issue #107 for basic images.

* This new configuration option will need to be documented.