### PR TITLE
Adds load by default configuration option to basic image. 

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -33,8 +33,8 @@ function islandora_web_annotations_admin(array $form, array &$form_state) {
   );
   $form['islandora_web_annotations_load_true'] = array(
       '#type' => 'checkbox',
-      '#title' => t('Load annotations by default for large images.'),
-      '#description' => t('When checked, annotations will be loaded by default for large images.  You will still be able to toggle annotations (view, hide).'),
+      '#title' => t('Load annotations by default for basic and large images.'),
+      '#description' => t('When checked, annotations will be loaded by default for basic and large images.  You will still be able to toggle annotations (view, hide).'),
       '#default_value' => variable_get('islandora_web_annotations_load_true', FALSE),
   );
   $form['islandora_web_annotations_namespace'] = array(

--- a/js/basic_image/basic_image.js
+++ b/js/basic_image/basic_image.js
@@ -12,6 +12,13 @@ jQuery(document).ready(function() {
     if(Drupal.settings.islandora_web_annotations.view == true) {
         var loadAnnotationsButton = jQuery('<button id="load-annotation-button" title="Load Annotations" class="annotator-adder-actions__button h-icon-annotate" onclick="getAnnotationsBasicImage()"></button>');
         loadAnnotationsButton.appendTo(jQuery(".islandora-basic-image-content")[0]);
+
+        // Make sure that the basic image has loaded before loading annotations by default.
+        jQuery("img[typeof='foaf:Image']").load(function() {
+            if (Drupal.settings.islandora_web_annotations.load_true == true) {
+                getAnnotationsBasicImage();
+            }
+        });
     }
 
     if(Drupal.settings.islandora_web_annotations.create == true) {


### PR DESCRIPTION
# What does this Pull Request do?
Resolves issue with loading annotations by default for small images - See issue #107. 

# What's new?
When the load annotations by default configuration option is checked, annotations on basic images will load by default on page load (no need to press the load annotation button).

# How should this be tested?
* Check the load annotations configuration setting.
* Test that the annotations load properly on page load.
