### PR TITLE
Issue 121

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -37,6 +37,12 @@ function islandora_web_annotations_admin(array $form, array &$form_state) {
       '#description' => t('When checked, annotations will be loaded by default for large images.  You will still be able to toggle annotations (view, hide).'),
       '#default_value' => variable_get('islandora_web_annotations_load_true', FALSE),
   );
+  $form['islandora_web_annotations_remove_clipper'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Remove clipper for large images.'),
+      '#description' => t('When checked, the clipper from the large image solution pack will be removed.'),
+      '#default_value' => variable_get('islandora_web_annotations_remove_clipper', FALSE),
+  );
   $form['islandora_web_annotations_namespace'] = array(
       '#type' => 'textfield',
       '#title' => t('Annotation Namespace'),

--- a/islandora_web_annotations.module
+++ b/islandora_web_annotations.module
@@ -163,6 +163,8 @@ function islandora_web_annotations_init() {
     $verbose_messages = variable_get('islandora_web_annotations_verbose', FALSE);
     $hide_list_block = variable_get('islandora_web_annotations_hide_list_block', FALSE);
     $load_true = variable_get('islandora_web_annotations_load_true', FALSE);
+    $remove_clipper = variable_get('islandora_web_annotations_remove_clipper', FALSE);
+
     drupal_add_js(array('islandora_web_annotations' =>
                           array('user'=>$username,
                             'view' => $view,
@@ -173,7 +175,8 @@ function islandora_web_annotations_init() {
                             'delete_own'=>$delete_own,
                             'verbose_messages' =>$verbose_messages,
                             'hide_list_block' => $hide_list_block,
-                            'load_true' => $load_true
+                            'load_true' => $load_true,
+                            'remove_clipper' => $remove_clipper
                           )
                         ), array('type' => 'setting')
                   );

--- a/js/large_image/large_image.js
+++ b/js/large_image/large_image.js
@@ -24,6 +24,10 @@ jQuery(document).ready(function() {
     // Add a parent div with this class
     openSeaDragonDiv.wrap('<div class="islandora-openseadragon" id="openseadragon-wrapper"></div>');
 
+    if(Drupal.settings.islandora_web_annotations.remove_clipper == true) {
+        // Remove clipper icon element(s) provided with large image solution pack.
+        jQuery('#clip').remove();
+    }
 
     if(Drupal.settings.islandora_web_annotations.view == true) {
         var saveButton = jQuery('<button id="load-annotation-button" title="Load Annotations" class="annotator-adder-actions__button h-icon-annotate" onclick="getAnnotationsLargeImage()"></button>');


### PR DESCRIPTION
# What does this Pull Request do?
Provides a configuration option to remove the clipper icon that is displayed by default via the large image solution pack (addressing issue https://github.com/digitalutsc/islandora_web_annotations/issues/121).

# What's new?
A configuration option to remove the clipper icon that is displayed with content models that use the large image JS.

# How should this be tested?
* Verify that when the configuration is checked, that the clipper icon is removed from large image based content models and that this does not introduce unintended JS issues.

# Additional Notes:
If and when an option to hide the clipper icon become available in Islandora Solution Pack Large Image (https://github.com/Islandora/islandora_solution_pack_large_image), we can remove this configuration setting and related code.  However, adding this in Islandora Web Annotations helps clean up the interface for some currently known production instances of Islandora Web Annotations that is targeting large images.

Explaining this new configuration option should be included in the documentation.