### PR TITLE
Video anno update

### DIFF
--- a/includes/AnnotationController.php
+++ b/includes/AnnotationController.php
@@ -146,6 +146,15 @@ function updateAnnotation(){
 
             $annotationID  = $annotationData["pid"];
             $ETag = $annotationData["checksum"];
+
+            // Immediately after creating an annotation, if the user edits it
+            // It comes in with additional data fields that needs to be cleanup.
+            if (array_key_exists('rows', $annotationData)) {
+              unset($annotationData["total"]);
+              unset($annotationData["rows"]);
+            }
+            unset($annotationData["annotationContainerID"]);
+            unset($annotationData["checksum"]);
         } else {
             throw new Exception("Delete request not valid.");
         }

--- a/js/video/video.js
+++ b/js/video/video.js
@@ -156,13 +156,19 @@ function applyPermissionsOnView(annotations){
 jQuery(document).ajaxComplete(function(event, jqXHR, ajaxOptions) {
     if (ajaxOptions.type === 'POST' && /\/islandora_web_annotations/.test(ajaxOptions.url)) {
         var jsonData = JSON.parse(jqXHR.responseText);
-        var PID = jsonData.rows[0].pid;
-        var checksum = jsonData.rows[0].checksum;
-        var annoLength = ova.annotator.plugins["Store"].annotations.length;
-        var lastAnnoIndex = Number(annoLength) - 1;
-        // Set annotation PID
-        ova.annotator.plugins["Store"].annotations[lastAnnoIndex].pid = PID;
-        ova.annotator.plugins["Store"].annotations[lastAnnoIndex].checksum = checksum;
+
+        // Basic error check
+        if(jsonData.rows[0]){
+            var PID = jsonData.rows[0].pid;
+            var checksum = jsonData.rows[0].checksum;
+            var annoLength = ova.annotator.plugins["Store"].annotations.length;
+            var lastAnnoIndex = Number(annoLength) - 1;
+            // Set annotation PID
+            ova.annotator.plugins["Store"].annotations[lastAnnoIndex].pid = PID;
+            ova.annotator.plugins["Store"].annotations[lastAnnoIndex].checksum = checksum;
+        } else {
+            alert("Error in creating the annotation.");
+        }
     }
 });
 

--- a/js/video/video.js
+++ b/js/video/video.js
@@ -110,7 +110,7 @@ jQuery(document).ready(function() {
     });
 
     ova.annotator.subscribe('annotationCreated', function(annotation){
-        var verbose_message = "Annotation successfully created: " + JSON.stringify(annotation);;
+        var verbose_message = "Annotation successfully created: " + JSON.stringify(annotation);
         var short_message = "Annotation successfully created.";
         verbose_alert(short_message, verbose_message);
     });
@@ -126,6 +126,8 @@ jQuery(document).ready(function() {
         var short_message = "Annotation successfully deleted.";
         verbose_alert(short_message, verbose_message);
     });
+
+
 });
 
 function applyPermissionsOnView(annotations){
@@ -143,6 +145,26 @@ function applyPermissionsOnView(annotations){
     }
 
 }
+
+
+/**
+ * issue#123
+ * Due to an bug in the annotator js library, the  annotationCreated does not return the pid of the created annotation.
+ * We need to attach a POST listener to get this info and update the store.
+ * This is required to enable the user to edit the annotation immediately after creating it.
+ */
+jQuery(document).ajaxComplete(function(event, jqXHR, ajaxOptions) {
+    if (ajaxOptions.type === 'POST' && /\/islandora_web_annotations/.test(ajaxOptions.url)) {
+        var jsonData = JSON.parse(jqXHR.responseText);
+        var PID = jsonData.rows[0].pid;
+        var checksum = jsonData.rows[0].checksum;
+        var annoLength = ova.annotator.plugins["Store"].annotations.length;
+        var lastAnnoIndex = Number(annoLength) - 1;
+        // Set annotation PID
+        ova.annotator.plugins["Store"].annotations[lastAnnoIndex].pid = PID;
+        ova.annotator.plugins["Store"].annotations[lastAnnoIndex].checksum = checksum;
+    }
+});
 
 function positionAnnotatorForm(formSelector){
     var left = jQuery(".vjs-selectionbar-RS").first().css("left");


### PR DESCRIPTION
# What does this Pull Request do?

This PR addresses this issue: https://github.com/digitalutsc/islandora_web_annotations/issues/123.  

The PID and checksum of the annotation that is created on the server is not available in the annotationCreated event.  This is Bug in the library: https://github.com/openannotation/annotator/issues/482.

A fix involving registering a ajaxComplete event to the POST even is suggested here: https://github.com/openannotation/annotator/issues/495.  This PR implements that.

# How should this be tested?
* Get the PR
* Create/Open video object
* Create an annotation
* Immediately after, without clicking the showAnnotations button or reloading the page, edit the annotation
* Afterwards, reload the page
* The update should be persisted
* Review the modified annotation in Fedora to ensure that the datastream contains a valid json-ld
