### PR TITLE
Updates video related routes to use type MENU_CALLBACK

### DIFF
--- a/islandora_web_annotations.module
+++ b/islandora_web_annotations.module
@@ -85,14 +85,16 @@ function islandora_web_annotations_menu() {
         'page callback' => 'getRoot',
         'access callback' => TRUE,
         'file' => 'includes/AnnotationController.php',
+        'type' => MENU_CALLBACK,
     );
 
     $items['islandora_web_annotations/search'] = array(
-        'title' => 'Create Web Annotation',
-        'description' => 'Add a new Web Annotation',
+        'title' => 'Search Web Annotations',
+        'description' => 'Search Web Annotations',
         'page callback' => 'searchAnnotations',
         'access callback' => TRUE,
         'file' => 'includes/AnnotationController.php',
+        'type' => MENU_CALLBACK,
     );
     // End: Video related routes
 


### PR DESCRIPTION
Updates video related routes to use type MENU_CALLBACK so that a link does not appear in navigation menus.

# What does this Pull Request do?
Adds MENU_CALLBACK type to the video related routes.  Updates the description and title of the video search route.

# How should this be tested?

1) There are some [known issues](http://stackoverflow.com/questions/5184852/drupal-how-to-rebuild-menu-navigation) when changing menu types.  In order to see the changes, you will need to disable Islandora Web Annotations via the module administration interface.   Then clear the cache, then re-enable the module.  The menus and  related links should be rebuilt and you should no longer see "Create Web Annotation" in the navigation menu.    

2) Do some sanity checking on video annotation functionality.