### PR TITLE
Removes checkboxes from Open Video Annotation editor window. 

### DIFF
--- a/js/video/video.js
+++ b/js/video/video.js
@@ -99,8 +99,14 @@ jQuery(document).ready(function() {
     });
 
     ova.annotator.subscribe('annotationEditorShown', function(viewer, annotations){
+
+        // Remove the list items which contain default permission checkboxes
+        // from the Open Video Annotation editor.  We do not use these.
+        jQuery('li.annotator-checkbox').remove();
+
         if(jQuery(".islandora-oralhistories-object").length > 0){
             positionAnnotatorForm(".annotator-editor");
+
         }
 
     });


### PR DESCRIPTION
# What does this Pull Request do?
Removes checkboxes from Open Video Annotation editor window. See issue #130.

# What's new?
Removes the checkboxes (and associated labels) from Open Video Annotation editor window which are not used in our implementation.

# How should this be tested?
* After pulling the changes, clear your Drupal cache and browser cache.
* When creating a video annotation, you should no longer see the checkboxes under the textarea where you type in annotations.
* You should still be able to annotate videos as before.