### PR TITLE
add scrolling to video annotation

### DIFF
--- a/css/video/video.css
+++ b/css/video/video.css
@@ -1,5 +1,4 @@
-.annotator-widget.annotator-listing
-{
+.annotator-widget.annotator-listing {
     max-height: 300px;
     overflow-y: auto;
 }

--- a/css/video/video.css
+++ b/css/video/video.css
@@ -1,5 +1,5 @@
-
-.richText-annotation {
+.annotator-widget.annotator-listing
+{
     max-height: 300px;
     overflow-y: auto;
 }

--- a/css/video/video.css
+++ b/css/video/video.css
@@ -1,0 +1,5 @@
+
+.richText-annotation {
+    max-height: 300px;
+    overflow-y: auto;
+}


### PR DESCRIPTION
# What does this Pull Request do?
This PR addresses this issue: https://github.com/digitalutsc/islandora_web_annotations/issues/135

# What's new?
* Adds a css file for video to ensure that the long annotations scroll rather than extend beyond the screen page.

# How should this be tested?
* Re import the video context config: https://github.com/digitalutsc/islandora_web_annotations/wiki/Configuration:-Video
* Create a long annotation
* Verify that view scrolls if the annotation is large