### PR TITLE
update array syntax to support php 5.3

### DIFF
--- a/includes/AnnotationController.php
+++ b/includes/AnnotationController.php
@@ -60,7 +60,7 @@ function createAnnotationForVideo($json){
 
     $annotationData = json_decode($output, true);
 
-    $arrResult["rows"] = [];
+    $arrResult["rows"] = array();
     array_push(  $arrResult["rows"], $annotationData);
     $arrResult["total"] = 1;
 
@@ -83,7 +83,7 @@ function searchAnnotations(){
     $annotationData = json_decode($output, true);
     $items = $annotationData["first"]["items"];
 
-    $arrResult["rows"] = [];
+    $arrResult["rows"] = array();
 
     for($i = 0; $i < count($items); $i++) {
         $items[$i]["annotationContainerID"] = $AnnotationContainerPID;


### PR DESCRIPTION
# What does this Pull Request do?
https://github.com/digitalutsc/islandora_web_annotations/issues/138 is related to array syntax changes in php 5.4 vs php 5.3.  We were using array syntax that is backward compatible with 5.3.  Travis failed to catch this due to php 5.3 not being in the travis config.

# How should this be tested?
* This PR changes the array to the syntax that is compatabile with 5.3 and acceptable in 5.4+.  The travis also has been updated via another commit to check for phpo 5.3.

* Sanity tests for creating an annotation.
* Ideally, we would need a 5.3 environment to test.  But, can possibly rely on travis to check this!