### PR TITLE
add try catch for delete

### DIFF
--- a/islandora_web_annotations.module
+++ b/islandora_web_annotations.module
@@ -27,110 +27,110 @@ define('ISLANDORA_WEB_ANNOTATION_DELETE_OWN', 'Delete Own Web Annotations');
  * Implements hook_menu().
  */
 function islandora_web_annotations_menu() {
-    $items = array();
-    $items['islandora_web_annotations/create'] = array(
-        'title' => 'Create Web Annotation',
-        'description' => 'Add a new Web Annotation',
-        'page callback' => 'createAnnotation',
-        'access callback' => TRUE,
-        'file' => 'includes/AnnotationController.php',
-        'access arguments' => array(ISLANDORA_WEB_ANNOTATION_CREATE),
-        'type' => MENU_CALLBACK,
-    );
+  $items = array();
+  $items['islandora_web_annotations/create'] = array(
+    'title' => 'Create Web Annotation',
+    'description' => 'Add a new Web Annotation',
+    'page callback' => 'createAnnotation',
+    'access callback' => TRUE,
+    'file' => 'includes/AnnotationController.php',
+    'access arguments' => array(ISLANDORA_WEB_ANNOTATION_CREATE),
+    'type' => MENU_CALLBACK,
+  );
 
-    $items['islandora_web_annotations/get'] = array(
-        'title' => 'Get Web Annotation Container',
-        'description' => 'Get Annotation Container',
-        'page callback' => 'getAnnotationContainer',
-        'access callback' => TRUE,
-        'file' => 'includes/AnnotationController.php',
-        'access arguments' => array(ISLANDORA_WEB_ANNOTATION_VIEW),
-        'type' => MENU_CALLBACK,
-    );
+  $items['islandora_web_annotations/get'] = array(
+    'title' => 'Get Web Annotation Container',
+    'description' => 'Get Annotation Container',
+    'page callback' => 'getAnnotationContainer',
+    'access callback' => TRUE,
+    'file' => 'includes/AnnotationController.php',
+    'access arguments' => array(ISLANDORA_WEB_ANNOTATION_VIEW),
+    'type' => MENU_CALLBACK,
+  );
 
-    $items['islandora_web_annotations/update'] = array(
-        'title' => 'Update Annotation',
-        'description' => 'Update Annotation',
-        'page callback' => 'updateAnnotation',
-        'access callback' => TRUE,
-        'file' => 'includes/AnnotationController.php',
-        'access arguments' => array(ISLANDORA_WEB_ANNOTATION_EDIT_ANY, ISLANDORA_WEB_ANNOTATION_EDIT_OWN),
-        'type' => MENU_CALLBACK,
-    );
+  $items['islandora_web_annotations/update'] = array(
+    'title' => 'Update Annotation',
+    'description' => 'Update Annotation',
+    'page callback' => 'updateAnnotation',
+    'access callback' => TRUE,
+    'file' => 'includes/AnnotationController.php',
+    'access arguments' => array(ISLANDORA_WEB_ANNOTATION_EDIT_ANY, ISLANDORA_WEB_ANNOTATION_EDIT_OWN),
+    'type' => MENU_CALLBACK,
+  );
 
-    $items['islandora_web_annotations/delete'] = array(
-        'title' => 'Delete Annotation',
-        'description' => 'Delete Annotation',
-        'page callback' => 'deleteAnnotation',
-        'access callback' => TRUE,
-        'file' => 'includes/AnnotationController.php',
-        'access arguments' => array(ISLANDORA_WEB_ANNOTATION_DELETE_ANY, ISLANDORA_WEB_ANNOTATION_DELETE_OWN),
-        'type' => MENU_CALLBACK,
-    );
+  $items['islandora_web_annotations/delete'] = array(
+    'title' => 'Delete Annotation',
+    'description' => 'Delete Annotation',
+    'page callback' => 'deleteAnnotation',
+    'access callback' => TRUE,
+    'file' => 'includes/AnnotationController.php',
+    'access arguments' => array(ISLANDORA_WEB_ANNOTATION_DELETE_ANY, ISLANDORA_WEB_ANNOTATION_DELETE_OWN),
+    'type' => MENU_CALLBACK,
+  );
 
-    $items['admin/islandora/tools/web_annotations'] = array(
-        'title' => 'Web Annotations',
-        'description' => 'Web Annotation related configuration options',
-        'page callback' => 'drupal_get_form',
-        'page arguments' => array('islandora_web_annotations_admin'),
-        'access arguments' => array('administer site configuration'),
-        'file' => 'includes/admin.form.inc',
-        'type' => MENU_NORMAL_ITEM,
-    );
+  $items['admin/islandora/tools/web_annotations'] = array(
+    'title' => 'Web Annotations',
+    'description' => 'Web Annotation related configuration options',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('islandora_web_annotations_admin'),
+    'access arguments' => array('administer site configuration'),
+    'file' => 'includes/admin.form.inc',
+    'type' => MENU_NORMAL_ITEM,
+  );
 
-    // Begin: Video related routes
-    $items['islandora_web_annotations'] = array(
-        'title' => 'Create Web Annotation',
-        'description' => 'Add a new Web Annotation',
-        'page callback' => 'getRoot',
-        'access callback' => TRUE,
-        'file' => 'includes/AnnotationController.php',
-        'type' => MENU_CALLBACK,
-    );
+  // Begin: Video related routes
+  $items['islandora_web_annotations'] = array(
+    'title' => 'Create Web Annotation',
+    'description' => 'Add a new Web Annotation',
+    'page callback' => 'getRoot',
+    'access callback' => TRUE,
+    'file' => 'includes/AnnotationController.php',
+    'type' => MENU_CALLBACK,
+  );
 
-    $items['islandora_web_annotations/search'] = array(
-        'title' => 'Search Web Annotations',
-        'description' => 'Search Web Annotations',
-        'page callback' => 'searchAnnotations',
-        'access callback' => TRUE,
-        'file' => 'includes/AnnotationController.php',
-        'type' => MENU_CALLBACK,
-    );
-    // End: Video related routes
+  $items['islandora_web_annotations/search'] = array(
+    'title' => 'Search Web Annotations',
+    'description' => 'Search Web Annotations',
+    'page callback' => 'searchAnnotations',
+    'access callback' => TRUE,
+    'file' => 'includes/AnnotationController.php',
+    'type' => MENU_CALLBACK,
+  );
+  // End: Video related routes
 
-    return $items;
+  return $items;
 }
 
 /**
  * Implements hook_permission().
  */
 function islandora_web_annotations_permission() {
-    return array(
-        ISLANDORA_WEB_ANNOTATION_VIEW => array(
-            'title' => t('View web annotations'),
-            'description' => t('view web annotations.'),
-        ),
-        ISLANDORA_WEB_ANNOTATION_CREATE => array(
-            'title' => t('Create web annotations'),
-            'description' => t('create web annotations'),
-        ),
-        ISLANDORA_WEB_ANNOTATION_EDIT_ANY => array(
-            'title' => t('Edit any web annotations'),
-            'description' => t('edit any web annotations'),
-        ),
-        ISLANDORA_WEB_ANNOTATION_DELETE_ANY => array(
-            'title' => t('Delete any web annotations'),
-            'description' => t('delete any web annotations'),
-        ),
-        ISLANDORA_WEB_ANNOTATION_EDIT_OWN => array(
-            'title' => t('Edit own web annotations'),
-            'description' => t('edit own web annotations'),
-        ),
-        ISLANDORA_WEB_ANNOTATION_DELETE_OWN => array(
-            'title' => t('Delete own web annotations'),
-            'description' => t('delete own web annotations'),
-        ),
-    );
+  return array(
+    ISLANDORA_WEB_ANNOTATION_VIEW => array(
+      'title' => t('View web annotations'),
+      'description' => t('view web annotations.'),
+    ),
+    ISLANDORA_WEB_ANNOTATION_CREATE => array(
+      'title' => t('Create web annotations'),
+      'description' => t('create web annotations'),
+    ),
+    ISLANDORA_WEB_ANNOTATION_EDIT_ANY => array(
+      'title' => t('Edit any web annotations'),
+      'description' => t('edit any web annotations'),
+    ),
+    ISLANDORA_WEB_ANNOTATION_DELETE_ANY => array(
+      'title' => t('Delete any web annotations'),
+      'description' => t('delete any web annotations'),
+    ),
+    ISLANDORA_WEB_ANNOTATION_EDIT_OWN => array(
+      'title' => t('Edit own web annotations'),
+      'description' => t('edit own web annotations'),
+    ),
+    ISLANDORA_WEB_ANNOTATION_DELETE_OWN => array(
+      'title' => t('Delete own web annotations'),
+      'description' => t('delete own web annotations'),
+    ),
+  );
 }
 
 
@@ -148,63 +148,63 @@ function islandora_web_annotations_views_api() {
  * Send user access related information to js for access control
  */
 function islandora_web_annotations_init() {
-    global $user;
-    $username = "anonymous";
+  global $user;
+  $username = "anonymous";
 
-    if (isset($user->name)) {
-        $username = $user->name;
-    }
+  if (isset($user->name)) {
+    $username = $user->name;
+  }
 
-    $view = user_access(ISLANDORA_WEB_ANNOTATION_VIEW);
-    $create = user_access(ISLANDORA_WEB_ANNOTATION_CREATE);
-    $edit_any = user_access(ISLANDORA_WEB_ANNOTATION_EDIT_ANY);
-    $delete_any = user_access(ISLANDORA_WEB_ANNOTATION_DELETE_ANY);
-    $edit_own = user_access(ISLANDORA_WEB_ANNOTATION_EDIT_OWN);
-    $delete_own = user_access(ISLANDORA_WEB_ANNOTATION_DELETE_OWN);
+  $view = user_access(ISLANDORA_WEB_ANNOTATION_VIEW);
+  $create = user_access(ISLANDORA_WEB_ANNOTATION_CREATE);
+  $edit_any = user_access(ISLANDORA_WEB_ANNOTATION_EDIT_ANY);
+  $delete_any = user_access(ISLANDORA_WEB_ANNOTATION_DELETE_ANY);
+  $edit_own = user_access(ISLANDORA_WEB_ANNOTATION_EDIT_OWN);
+  $delete_own = user_access(ISLANDORA_WEB_ANNOTATION_DELETE_OWN);
 
-    $verbose_messages = variable_get('islandora_web_annotations_verbose', FALSE);
-    $hide_list_block = variable_get('islandora_web_annotations_hide_list_block', FALSE);
-    $load_true = variable_get('islandora_web_annotations_load_true', FALSE);
-    $remove_clipper = variable_get('islandora_web_annotations_remove_clipper', FALSE);
+  $verbose_messages = variable_get('islandora_web_annotations_verbose', FALSE);
+  $hide_list_block = variable_get('islandora_web_annotations_hide_list_block', FALSE);
+  $load_true = variable_get('islandora_web_annotations_load_true', FALSE);
+  $remove_clipper = variable_get('islandora_web_annotations_remove_clipper', FALSE);
 
-    drupal_add_js(array('islandora_web_annotations' =>
-                          array('user'=>$username,
-                            'view' => $view,
-                            'create'=>$create,
-                            'edit_any'=>$edit_any,
-                            'delete_any'=>$delete_any,
-                            'edit_own'=>$edit_own,
-                            'delete_own'=>$delete_own,
-                            'verbose_messages' =>$verbose_messages,
-                            'hide_list_block' => $hide_list_block,
-                            'load_true' => $load_true,
-                            'remove_clipper' => $remove_clipper
-                          )
-                        ), array('type' => 'setting')
-                  );
+  drupal_add_js(array('islandora_web_annotations' =>
+    array('user'=>$username,
+      'view' => $view,
+      'create'=>$create,
+      'edit_any'=>$edit_any,
+      'delete_any'=>$delete_any,
+      'edit_own'=>$edit_own,
+      'delete_own'=>$delete_own,
+      'verbose_messages' =>$verbose_messages,
+      'hide_list_block' => $hide_list_block,
+      'load_true' => $load_true,
+      'remove_clipper' => $remove_clipper
+    )
+  ), array('type' => 'setting')
+  );
 }
 
 
 function islandora_web_annotations_islandora_required_objects(IslandoraTuque $connection) {
-    try{
+  try{
 
-        $object1 = installObject($connection, AnnotationConstants::WADM_CONTENT_MODEL, AnnotationConstants::WADM_CONTENT_MODEL_LABEL, "webannotation_ds_composite_model.xml");
-        $object2 = installObject($connection, AnnotationConstants::WADMContainer_CONTENT_MODEL, AnnotationConstants::WADMContainer_CONTENT_MODEL_LABEL, "webannotation_ds_composite_model.xml");
+    $object1 = installObject($connection, AnnotationConstants::WADM_CONTENT_MODEL, AnnotationConstants::WADM_CONTENT_MODEL_LABEL, "webannotation_ds_composite_model.xml");
+    $object2 = installObject($connection, AnnotationConstants::WADMContainer_CONTENT_MODEL, AnnotationConstants::WADMContainer_CONTENT_MODEL_LABEL, "webannotation_ds_composite_model.xml");
 
-        return array(
-            'islandora_web_annotations' => array(
-                'title' => 'Islandora Web Annotations',
-                'objects' => array(
-                    $object1,
-                    $object2,
-                ),
-            ),
-        );
+    return array(
+      'islandora_web_annotations' => array(
+        'title' => 'Islandora Web Annotations',
+        'objects' => array(
+          $object1,
+          $object2,
+        ),
+      ),
+    );
 
-    } catch(Exception $e) {
-        watchdog(AnnotationConstants::MODULE_NAME, 'Error in installIslandoraObject: %t', array('%t' => $e->getMessage()), WATCHDOG_ERROR);
-        return null;
-    }
+  } catch(Exception $e) {
+    watchdog(AnnotationConstants::MODULE_NAME, 'Error in installIslandoraObject: %t', array('%t' => $e->getMessage()), WATCHDOG_ERROR);
+    return null;
+  }
 }
 
 /**
@@ -214,52 +214,57 @@ function islandora_web_annotations_islandora_required_objects(IslandoraTuque $co
  */
 
 function islandora_web_annotations_islandora_object_alter(AbstractObject $object, array &$context) {
-    // If delete action
-    if($context["action"] == "purge"){
-        $object_content_models = $object->relationships->get('info:fedora/fedora-system:def/model#', 'hasModel');
-        $type = $object_content_models[0]["object"]["value"];
+  // If delete action
+  if($context["action"] == "purge"){
+    $object_content_models = $object->relationships->get('info:fedora/fedora-system:def/model#', 'hasModel');
+    $type = $object_content_models[0]["object"]["value"];
 
-        // If it is an annotation
-        if($type == "islandora:WADMCModel"){
-            // Get the target PID, needed to get the container
-            $WADM_SEARCH_Object = $object->getDatastream("WADM");
-            $content = $WADM_SEARCH_Object->content;
-            $contentJson = json_decode($content);
-            $targetURL = $contentJson->target;
-            $targetPID = AnnotationUtil::getPIDfromURL($targetURL);
+    // If it is an annotation
+    if($type == "islandora:WADMCModel"){
+      try {
+        // Get the target PID, needed to get the container
+        $WADM_SEARCH_Object = $object->getDatastream("WADM");
+        $content = $WADM_SEARCH_Object->content;
+        $contentJson = json_decode($content);
+        $targetURL = $contentJson->target;
+        $targetPID = AnnotationUtil::getPIDfromURL($targetURL);
 
-            // Get the container
-            $oAnnotationContainer = new AnnotationContainer();
-            $annotationContainerID = $oAnnotationContainer->getAnnotationContainerPID($targetPID);
+        // Get the container
+        $oAnnotationContainer = new AnnotationContainer();
+        $annotationContainerID = $oAnnotationContainer->getAnnotationContainerPID($targetPID);
 
-            // Remove the annotation from the container
-            $annoID = $object->id;
-            $oAnnotationContainer->removeItem($annotationContainerID, $annoID);
-        }
+        // Remove the annotation from the container
+        $annoID = $object->id;
+        $oAnnotationContainer->removeItem($annotationContainerID, $annoID);
+      }
+      catch (Exception $e) {
+        watchdog(AnnotationConstants::MODULE_NAME, 'Error in updating AnnotationContainer after deleting an annotation: %t', array('%t' => $e->getMessage()), WATCHDOG_ERROR);
+      }
     }
+  }
 }
 
 
 function installObject($connection, $contentModel, $contentModelLabel, $composite_model_fileName){
-    try{
-        $object = $connection->repository->constructObject($contentModel);
-        $object->owner = 'fedoraAdmin';
-        $object->label = $contentModelLabel;
-        $object->models = array("fedora-system:ContentModel-3.0");
+  try{
+    $object = $connection->repository->constructObject($contentModel);
+    $object->owner = 'fedoraAdmin';
+    $object->label = $contentModelLabel;
+    $object->models = array("fedora-system:ContentModel-3.0");
 
-        $objectID =  $object->id;
+    $objectID =  $object->id;
 
-        $ds_composite_datastream = $object->constructDatastream('DS-COMPOSITE-MODEL', 'X');
-        $ds_composite_datastream->label = 'DS-COMPOSITE-MODEL';
-        $ds_composite_datastream->mimetype = 'text/xml';
-        $moduleDir = realpath(__DIR__ );
-        $ds_composite_datastream->setContentFromFile($moduleDir . "/xml/" . $composite_model_fileName, FALSE);
-        $object->ingestDatastream($ds_composite_datastream);
+    $ds_composite_datastream = $object->constructDatastream('DS-COMPOSITE-MODEL', 'X');
+    $ds_composite_datastream->label = 'DS-COMPOSITE-MODEL';
+    $ds_composite_datastream->mimetype = 'text/xml';
+    $moduleDir = realpath(__DIR__ );
+    $ds_composite_datastream->setContentFromFile($moduleDir . "/xml/" . $composite_model_fileName, FALSE);
+    $object->ingestDatastream($ds_composite_datastream);
 
-        watchdog(AnnotationConstants::MODULE_NAME, 'installObject with pid: %t', array('%t' => $objectID), WATCHDOG_INFO);
-        return $object;
-    } catch(Exception $e) {
-        watchdog(AnnotationConstants::MODULE_NAME, 'Error in installIslandoraObject: %t', array('%t' => $e->getMessage()), WATCHDOG_ERROR);
-        return null;
-    }
+    watchdog(AnnotationConstants::MODULE_NAME, 'installObject with pid: %t', array('%t' => $objectID), WATCHDOG_INFO);
+    return $object;
+  } catch(Exception $e) {
+    watchdog(AnnotationConstants::MODULE_NAME, 'Error in installIslandoraObject: %t', array('%t' => $e->getMessage()), WATCHDOG_ERROR);
+    return null;
+  }
 }


### PR DESCRIPTION
# What does this Pull Request do?
Address this issue: https://github.com/digitalutsc/islandora_web_annotations/issues/105

# What's new?
Adds a try catch to not error out even if the annotation container could not be updated for some reason.

# How should this be tested?
islandora_web_annotations_islandora_object_alter in the islandora_web_annotation.module is updated with try catch.  To test, would have to simulate a failure in getting the annotation container or manually throw an exception in that function.  Verify that the annotation itself is deleted.
