### PR TITLE
adjust position for oh annotaiton edit

### DIFF
--- a/lib/js/ova.js
+++ b/lib/js/ova.js
@@ -716,6 +716,7 @@ vjsAnnotation.prototype = {
 		annotator.editor.element[0].style.display = 'block';
 		
 		this._setOverRS(annotator.editor.element);
+		positionAnnotatorForm(".annotator-editor");
 	},
 	_sumPercent: function(seconds,percent) {
 		//the percentage is in %


### PR DESCRIPTION
# What does this Pull Request do?
This PR addresses an issue related to https://github.com/digitalutsc/islandora_web_annotations/issues/144.  It along with https://github.com/digitalutsc/islandora_solution_pack_oralhistories/pull/47 resolves the issue related not being able to create video annotation in Chrome.

# What's new?
* It calls the re positioning function after the range has been changed to ensure that that editor is shown properly in Chrome.

# How should this be tested?
* Get the latest OH after https://github.com/digitalutsc/islandora_solution_pack_oralhistories/pull/47  is merged.
* Get this PR
* Go to Chrome and create a video annotation - should see a confirmation message
* Edit the newly created video annotation - should see a confirmation message
* Reload and verify that the annotation exists 