### PR TITLE
Ensure that the user is not able to create annotations without permission

### DIFF
--- a/js/basic_image/basic_image.js
+++ b/js/basic_image/basic_image.js
@@ -71,6 +71,11 @@ function initBasicImageAnnotation(){
         deleteAnnotation(annotation);
     });
 
+    // issue#151 - Ensure that the user is not able to create annotations if they do not have permission to do so
+    if(Drupal.settings.islandora_web_annotations.create == false) {
+        anno.hideSelectionWidget();
+    }
+
     jQuery("#add-annotation-button").remove();
     jQuery(".annotorious-hint").css("left", "45px");
 

--- a/js/basic_image/basic_image.js
+++ b/js/basic_image/basic_image.js
@@ -14,14 +14,14 @@ jQuery(document).ready(function() {
     if(Drupal.settings.islandora_web_annotations.view == true) {
         var loadAnnotationsButton = jQuery('<button id="load-annotation-button" title="Toggle Annotations" class="annotator-adder-actions__button h-icon-annotate" onclick="getAnnotationsBasicImage()"></button>');
         loadAnnotationsButton.appendTo(jQuery(".islandora-basic-image-content")[0]);
-      
+
         //Update button position for consistency.
         var update_pos_css = {
             top: image_top_pos,
             left: image_left_pos
         };
         jQuery("#load-annotation-button").css(update_pos_css);
-      
+
         // Make sure that the basic image has loaded before loading annotations by default.
         jQuery("img[typeof='foaf:Image']").load(function() {
             if (Drupal.settings.islandora_web_annotations.load_true == true) {
@@ -71,22 +71,24 @@ function initBasicImageAnnotation(){
         deleteAnnotation(annotation);
     });
 
-    // issue#151 - Ensure that the user is not able to create annotations if they do not have permission to do so
-    if(Drupal.settings.islandora_web_annotations.create == false) {
-        anno.hideSelectionWidget();
-    }
-
     jQuery("#add-annotation-button").remove();
     jQuery(".annotorious-hint").css("left", "45px");
-
 }
 
 function getAnnotationsBasicImage() {
+    // issue#151 - reset annotation
+    anno.showSelectionWidget();
+
     if(jQuery(".annotorious-hint-icon").is(":visible")=== false) {
         initBasicImageAnnotation();
     }
     var objectPID = getBasicImagePID();
     getAnnotations(objectPID);
+
+    // issue#151 - Ensure that the user is not able to create annotations if they do not have permission to do so
+    if(Drupal.settings.islandora_web_annotations.create == false) {
+        anno.hideSelectionWidget();
+    }
 }
 
 function getBasicImagePID() {


### PR DESCRIPTION
# What does this Pull Request do?
Addresses this issue: https://github.com/digitalutsc/islandora_web_annotations/issues/151

# What's new?
Hides the add annotation button option when use does not have the permission to do so.

# How should this be tested?
Please see the steps in the issue.