### PR TITLE
ensure that the conflict message is shown

### DIFF
--- a/js/base/base.js
+++ b/js/base/base.js
@@ -213,12 +213,13 @@ function updateAnnotation(annotationData) {
             var jsonData = JSON.parse(data);
             var status = jsonData.status;
             var annoInfo = jsonData.data;
-            var checksum = annoInfo.checksum;
-            var updatedText = annoInfo.body.text;
-            var creator = annoInfo.creator;
-            var created = annoInfo.created;
 
             if(status == "success") {
+                var checksum = annoInfo.checksum;
+                var updatedText = annoInfo.body.text;
+                var creator = annoInfo.creator;
+                var created = annoInfo.created;
+
                 updateAnnotationInfo(annotationPID, checksum, updatedText, creator, created);
                 var verbose_message = "Successfully updated the annotation: " + JSON.stringify(annoInfo);
                 var short_message = "Update successful.";


### PR DESCRIPTION
# What does this Pull Request do?
This PR addresses this issue: https://github.com/digitalutsc/islandora_web_annotations/issues/165

This is an regression bug introduced during enabling of html block back.  A property is being accessed when it is not defined, throwing a js error, thus the message does not get shown.  Ensured that the message gets shown.

# How should this be tested?
Get the PR and follow the steps in the issue.  Ensure that the conflict message is shown.