### PR TITLE
replace new line entity that is causing an invalid xml

### DIFF
--- a/includes/Annotation.php
+++ b/includes/Annotation.php
@@ -181,13 +181,13 @@ class Annotation implements interfaceAnnotation
 
         $textvalue = $annotationData["text"];
         $creator = $annotationMetadata["creator"];
-      
+
         $xml = new SimpleXMLElement('<?xml version="1.0" encoding="utf-8"?><annotation></annotation>');
 
         $xml->addChild('title', "Annotation for " . $targetID);
         $xml->addChild('target', $targetID);
         $xml->addChild('creator', $creator);
-        $xml = $this->addCadata('textvalue', $textvalue, $xml);
+        $this->addCadata('textvalue', $textvalue, $xml);
 
         // If video annotation
         if (array_key_exists('rangeTime', $annotationData)) {

--- a/includes/Annotation.php
+++ b/includes/Annotation.php
@@ -182,6 +182,9 @@ class Annotation implements interfaceAnnotation
         $textvalue = $annotationData["text"];
         $creator = $annotationMetadata["creator"];
 
+        // @nbsp; results in an invalid xml, replace that with &#160;
+        $textvalue = str_replace("&nbsp;", "&#160;", $textvalue);
+
         $xml = new SimpleXMLElement('<?xml version="1.0" encoding="utf-8"?><annotation></annotation>');
 
         $xml->addChild('title', "Annotation for " . $targetID);

--- a/includes/Annotation.php
+++ b/includes/Annotation.php
@@ -182,7 +182,7 @@ class Annotation implements interfaceAnnotation
         $textvalue = $annotationData["text"];
         $creator = $annotationMetadata["creator"];
 
-        // @nbsp; results in an invalid xml, replace that with &#160;
+        // &nbsp; results in an invalid xml, replace that with &#160;
         $textvalue = str_replace("&nbsp;", "&#160;", $textvalue);
 
         $xml = new SimpleXMLElement('<?xml version="1.0" encoding="utf-8"?><annotation></annotation>');

--- a/includes/Annotation.php
+++ b/includes/Annotation.php
@@ -181,16 +181,13 @@ class Annotation implements interfaceAnnotation
 
         $textvalue = $annotationData["text"];
         $creator = $annotationMetadata["creator"];
-
-        // &nbsp; results in an invalid xml, replace that with &#160;
-        $textvalue = str_replace("&nbsp;", "&#160;", $textvalue);
-
+      
         $xml = new SimpleXMLElement('<?xml version="1.0" encoding="utf-8"?><annotation></annotation>');
 
         $xml->addChild('title', "Annotation for " . $targetID);
         $xml->addChild('target', $targetID);
         $xml->addChild('creator', $creator);
-        $xml->addChild('textvalue', $textvalue);
+        $xml = $this->addCadata('textvalue', $textvalue, $xml);
 
         // If video annotation
         if (array_key_exists('rangeTime', $annotationData)) {
@@ -204,5 +201,26 @@ class Annotation implements interfaceAnnotation
 
         return $contentXML;
     }
+
+  /**
+   * Adds a CDATA property to an XML document.
+   *
+   * @param string $name
+   *   Name of property that should contain CDATA.
+   * @param string $value
+   *   Value that should be inserted into a CDATA child.
+   * @param object $parent
+   *   Element that the CDATA child should be attached too.
+   */
+  private function addCadata($name, $value, &$parent) {
+    $child = $parent->addChild($name);
+
+    if ($child !== NULL) {
+      $child_node = dom_import_simplexml($child);
+      $child_owner = $child_node->ownerDocument;
+      $child_node->appendChild($child_owner->createCDATASection($value));
+    }
+    return $child;
+  }
 
 }


### PR DESCRIPTION
# What does this Pull Request do?
This PR addresses an issue that was encountered during testing rich text annotations in video.  Rich text annotations with &nbsp; (new line) html content did not produce valid xml datastream for indexing.

# What's new?
* Put the text content of the html as CDATA in search datastream.

# How should this be tested?
* Get the PR
* Create an annotations with new line and complex html (i.e images)
* Verify that the annotation is indexed
