### PR TITLE
Addresses TypeError generated when user presses load annotation button when there are no annotations.

### DIFF
--- a/js/base/base.js
+++ b/js/base/base.js
@@ -119,6 +119,13 @@ function getAnnotations(targetObjectId) {
             // Extract data
             var jsonData = JSON.parse(data);
             annotationContainerID = jsonData["@id"];
+            if(typeof(jsonData.first) == 'undefined' ){
+                // first property is undefined when there are
+                // no annotations (or annotation container).
+                b_annotationsShown = false;
+                return false;
+            }
+
             var annotations = jsonData.first.items;
 
             for(var i = 0; i< annotations.length; i++) {


### PR DESCRIPTION
In some cases a TypeError is generated when user presses the load annotation button when there are no annotations.

# What does this Pull Request do?
Provides a conditional to check whether a variable is defined before proceeding with loading annotations.

# How should this be tested?
* Before pulling the changes, create a new basic image object.  Open you browser console.  Before making any annotations, press the toggle annotation button (load annotation button).  You should see a TypeError around line 122 of `base.js`.
* Pull the changes in this pull-request.   Clear your caches as appropriate.
* Create a basic image.  
* Open your browser console.  Before annotating the basic image object, press the toggle annotation button.  In the console you should no longer see the TypeError seen previously.