### PR TITLE
hide rubric button

### DIFF
--- a/js/video/video.js
+++ b/js/video/video.js
@@ -106,6 +106,8 @@ jQuery(document).ready(function() {
         // Remove the list items which contain default permission checkboxes
         // from the Open Video Annotation editor.  We do not use these.
         jQuery('li.annotator-checkbox').remove();
+        // issue-174
+        jQuery(".mce-i-rubric").parent().hide();
 
         if(jQuery(".islandora-oralhistories-object").length > 0){
             positionAnnotatorForm(".annotator-editor");


### PR DESCRIPTION
# What does this Pull Request do?
As per this issue: https://github.com/digitalutsc/islandora_web_annotations/issues/174, rubric is not required.  rubric button is hidden.

# How should this be tested?
* Get the PR
* Go to an object with video annotation
* Verify that the rubric button is now shown to the user (on create and update)