### PR TITLE
Issue 160

### DIFF
--- a/islandora_web_annotations.module
+++ b/islandora_web_annotations.module
@@ -147,7 +147,12 @@ function islandora_web_annotations_views_api() {
 /**
  * Send user access related information to js for access control
  */
-function islandora_web_annotations_init() {
+function islandora_web_annotations_islandora_view_object(AbstractObject $object) {
+  $pid = "unknown";
+  if (isset($object)) {
+    $pid = $object->id;
+  }
+
   global $user;
   $username = "anonymous";
 
@@ -169,6 +174,7 @@ function islandora_web_annotations_init() {
 
   drupal_add_js(array('islandora_web_annotations' =>
     array('user'=>$username,
+      'pid' => $pid,
       'view' => $view,
       'create'=>$create,
       'edit_any'=>$edit_any,

--- a/js/base/base.js
+++ b/js/base/base.js
@@ -42,8 +42,6 @@ function createAnnotation(targetObjectId, annotationData) {
         annotationData: annotationData
     };
 
-
-
     jQuery.ajax({
         url: location.protocol + '//' + location.host + '/islandora_web_annotations/create',
         dataType: 'json',

--- a/js/base/base.js
+++ b/js/base/base.js
@@ -33,11 +33,16 @@ function createAnnotation(targetObjectId, annotationData) {
     var metadata = {}
     metadata.creator = user;
 
+    // Ensure that canonical path is saved, not path autho
+    annotationData.context = g_contentURI;
+
     var annotation = {
         targetPid: targetObjectId,
         metadata: metadata,
         annotationData: annotationData
     };
+
+
 
     jQuery.ajax({
         url: location.protocol + '//' + location.host + '/islandora_web_annotations/create',
@@ -193,6 +198,8 @@ function updateAnnotation(annotationData) {
     delete annotationData.created;
     delete annotationData.checksum;
 
+    // Ensure that canonical path is saved, not path autho
+    annotationData.context = g_contentURI;
 
     var annotationPID = annotationData.pid;
     var annotation = {

--- a/js/basic_image/basic_image.js
+++ b/js/basic_image/basic_image.js
@@ -92,10 +92,7 @@ function getAnnotationsBasicImage() {
 }
 
 function getBasicImagePID() {
-    var objectURL = window.location.href;
-    var objectPID = objectURL.substr(objectURL.lastIndexOf('/') + 1);
-    objectPID = objectPID.replace("%3A", ":");
-    objectPID = objectPID.replace("#", "");
+    var objectPID = Drupal.settings.islandora_web_annotations.pid;
     return objectPID;
 }
 

--- a/js/basic_image/basic_image.js
+++ b/js/basic_image/basic_image.js
@@ -6,6 +6,7 @@
  */
 
 var g_contentType = "basic-image";
+var g_contentURI = window.location.href;
 
 jQuery(document).ready(function() {
     var image_position = jQuery(".islandora-basic-image-content img").position();
@@ -93,6 +94,7 @@ function getAnnotationsBasicImage() {
 
 function getBasicImagePID() {
     var objectPID = Drupal.settings.islandora_web_annotations.pid;
+    g_contentURI = location.protocol + '//' + location.host + "/islandora/object/" + objectPID
     return objectPID;
 }
 

--- a/js/large_image/large_image.js
+++ b/js/large_image/large_image.js
@@ -6,6 +6,7 @@
  */
 
 var g_contentType = "large-image";
+var g_contentURI = window.location.href;
 
 jQuery(document).ready(function() {
 
@@ -81,6 +82,7 @@ jQuery(document).ready(function() {
 
 
 function getAnnotationsLargeImage() {
-    var targetObjectId = Drupal.settings.islandoraOpenSeadragon.pid;
-    getAnnotations(targetObjectId);
+    var objectPID = Drupal.settings.islandora_web_annotations.pid;
+    g_contentURI = location.protocol + '//' + location.host + "/islandora/object/" + objectPID
+    getAnnotations(objectPID);
 }

--- a/js/video/video.js
+++ b/js/video/video.js
@@ -14,9 +14,8 @@ jQuery(document).ready(function() {
 
     preload="none"
 
-    var objectUri = window.location.href;
-    objectUri = objectUri.replace("%3A", ":");
-    objectUri = objectUri.replace("#", "");
+    var objectPID = Drupal.settings.islandora_web_annotations.pid;
+    var objectUri = location.protocol + '//' + location.host + "/islandora/object/" + objectPID
 
     var options = {
         optionsAnnotator: {


### PR DESCRIPTION
# What does this Pull Request do?
This PR addresses this issue: https://github.com/digitalutsc/islandora_web_annotations/issues/160

* Able to load basic image and video js annotations created with or without pathauto, while having pathauto enabled or disabled
* JsonLD for basic/large image annotations should store un-aliases value for context/target properties

# How should this be tested?
* Get the PR
* Create annotations without pathauto for basic image
* Enable pathauto
* Verify that annotations can be loaded
* Create another annotation
* Verify that the json-ld context and target properties do not contain the alias path
* Please repeat the above steps for large image and video.js

Notes:
* when path auto is enabled, the annotations block do not show because the targeting won't be applied.  

If everything goes well, please do squash merge.  
