### PR TITLE
Adds datetime as xsd:dateTime with the UTC timezone expressed as Z.

### DIFF
--- a/includes/Annotation.php
+++ b/includes/Annotation.php
@@ -140,12 +140,14 @@ class Annotation implements interfaceAnnotation
 
         );
 
+        $annotationUtils = new AnnotationUtil();
+        $utc_now = $annotationUtils->utcNow();
         if($actionType == "create") {
-            $now = date("Y-m-d H:i:s");
-            $metadata = array('creator' => $annotationMetadata["creator"], 'created' => $now);
+          $now = $utc_now;
+          $metadata = array('creator' => $annotationMetadata["creator"], 'created' => $now);
         }
         if($actionType == "update"){
-            $now = date("Y-m-d H:i:s");
+            $now = $utc_now;
             $metadata = array('creator' => $annotationMetadata["creator"], 'created' => $annotationMetadata["created"], 'modifiedBy' => $annotationMetadata["author"], 'modified' => $now);
         }
 

--- a/includes/Annotation.php
+++ b/includes/Annotation.php
@@ -143,8 +143,8 @@ class Annotation implements interfaceAnnotation
         $annotationUtils = new AnnotationUtil();
         $utc_now = $annotationUtils->utcNow();
         if($actionType == "create") {
-          $now = $utc_now;
-          $metadata = array('creator' => $annotationMetadata["creator"], 'created' => $now);
+            $now = $utc_now;
+            $metadata = array('creator' => $annotationMetadata["creator"], 'created' => $now);
         }
         if($actionType == "update"){
             $now = $utc_now;

--- a/includes/AnnotationUtil.php
+++ b/includes/AnnotationUtil.php
@@ -98,4 +98,15 @@ class AnnotationUtil
         $targetPID = substr($url, strrpos($url, '/') + 1);
         return $targetPID;
     }
+
+    /**
+     *  Returns datetime as a xsd:dateTime with the UTC timezone expressed as "Z".
+     */
+    public function utcNow() {
+      $now = date("Y-m-d H:i:s");
+      $utc_now = new DateTime($now);
+      $utc_now->setTimezone(new DateTimeZone('UTC'));
+      return $utc_now->format('Y-m-d\TH:i:s\Z');
+    }
+
 }


### PR DESCRIPTION
Adds datetime as xsd:dateTime with the UTC timezone expressed as Z.  Addresses issue #191.

# What does this Pull Request do?
Created and updated properties now use datetime value as a xsd:dateTime with the UTC timezone expressed as Z for basic and large image (as required by the [Web Annotation Data Model](https://www.w3.org/TR/annotation-model/)).  This was already handled properly for video and audio using the Open Video Annotation library (OVA).

# What's new?
Uses UTC time with timezone expressed as Z as the value for created and updated  properties. 

# How should this be tested?
After pulling the changes, turn on verbose messaging in the Web Annotation Utility configuration settings.  Create and update annotations for the supported content models.  The values of the created and updated properties should display datetimes adjusted to use `Y-m-d\TH:i:s\Z` (or `Y-m-d\TH:i:s.v\Z` for audio, video and oral histories) .

# Additional Notes:
Note that milliseconds is optional.  The OVA library uses milliseconds.  We have chosen not to use milliseconds for created and updated for basic and large image unless the need arises.  Doing otherwise will require some additional custom code, for example, something like that in this [comment in the PHP docs](http://php.net/manual/en/function.gmdate.php#119814).  PHP 7 includes a new format parameter for milliseconds 'v', but this is not available in earlier versions of PHP.