### PR TITLE
Jsonld cleanup

### DIFF
--- a/includes/Annotation.php
+++ b/includes/Annotation.php
@@ -128,6 +128,9 @@ class Annotation implements interfaceAnnotation
         global $base_url;
         $annotationIRI = $base_url . "/islandora/object/" . $pid;
 
+        $userURL = $base_url . "/users/" . $annotationMetadata["creator"];
+
+
         $data = array(
           "@context" => array(AnnotationConstants::ONTOLOGY_CONTEXT_ANNOTATION),
           "@id" => $annotationIRI,
@@ -143,10 +146,10 @@ class Annotation implements interfaceAnnotation
         $utc_now = AnnotationUtil::utcNow();
         if($actionType == "create") {
             $now = $utc_now;
-            $metadata = array('creator' => $annotationMetadata["creator"], 'created' => $now);
+            $metadata = array('creator' => $userURL, 'created' => $now);
         } elseif($actionType == "update") {
             $now = $utc_now;
-            $metadata = array('creator' => $annotationMetadata["creator"], 'created' => $annotationMetadata["created"], 'modified' => $now);
+            $metadata = array('creator' => $userURL, 'created' => $annotationMetadata["created"], 'modified' => $now);
         }
 
         $data = array_merge($data, $metadata);

--- a/includes/Annotation.php
+++ b/includes/Annotation.php
@@ -146,7 +146,7 @@ class Annotation implements interfaceAnnotation
             $metadata = array('creator' => $annotationMetadata["creator"], 'created' => $now);
         } elseif($actionType == "update") {
             $now = $utc_now;
-            $metadata = array('creator' => $annotationMetadata["creator"], 'created' => $annotationMetadata["created"], 'modifiedBy' => $annotationMetadata["author"], 'modified' => $now);
+            $metadata = array('creator' => $annotationMetadata["creator"], 'created' => $annotationMetadata["created"], 'modified' => $now);
         }
 
         $data = array_merge($data, $metadata);

--- a/includes/AnnotationContainer.php
+++ b/includes/AnnotationContainer.php
@@ -10,6 +10,7 @@ require_once(__DIR__ . '/AnnotationUtil.php');
 require_once(__DIR__ . '/interfaceAnnotationContainer.php');
 require_once(__DIR__ . '/Annotation.php');
 require_once(__DIR__ . '/AnnotationContainerTracker.php');
+require_once(__DIR__ . '/AnnotationFormatTranslator.php');
 module_load_include('inc', 'islandora', 'includes/solution_packs');
 
 class AnnotationContainer implements interfaceAnnotationContainer
@@ -86,15 +87,12 @@ class AnnotationContainer implements interfaceAnnotationContainer
                 }
                 $dsContent = (string)$WADMObject->content;
                 $checksum = $WADMObject->checksum;
-
                 if($dsContent != "NotFound") {
-                    $dsContentJson = json_decode($dsContent);
-                    $body = $dsContentJson->body;
-                    $body->pid = $items[$i];
-                    $body->creator = $dsContentJson->creator;
-                    $body->created = $dsContentJson->created;
-                    $body->checksum = $checksum;
-                    array_push($newArray, $body);
+                  $dsContentJson = json_decode($dsContent);
+                  $body = conver_W3C_to_lib_annotation_datamodel($dsContentJson);
+                  $body->checksum = $checksum;
+
+                  array_push($newArray, $body);
                 }
             }
 

--- a/includes/AnnotationContainer.php
+++ b/includes/AnnotationContainer.php
@@ -223,7 +223,7 @@ class AnnotationContainer implements interfaceAnnotationContainer
             "@type" => array("BasicContainer", "AnnotationCollection"),
             "total" => "0",
             "label" => "annotationContainer for " . $targetObjectID,
-            "first" => (object) array("id" => $targetPageID, "type" => AnnotationConstants::ANNOTATION_CLASS_2, "items" => array())
+            "first" => (object) array("@id" => $targetPageID, "@type" => AnnotationConstants::ANNOTATION_CLASS_2, "items" => array())
         );
         $annotationContainerJsonLD = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
         return $annotationContainerJsonLD;

--- a/includes/AnnotationContainer.php
+++ b/includes/AnnotationContainer.php
@@ -91,7 +91,7 @@ class AnnotationContainer implements interfaceAnnotationContainer
                   $dsContentJson = json_decode($dsContent);
                   $body = conver_W3C_to_lib_annotation_datamodel($dsContentJson);
                   $body->checksum = $checksum;
-
+                  $body->pid = $items[$i];
                   array_push($newArray, $body);
                 }
             }

--- a/includes/AnnotationContainer.php
+++ b/includes/AnnotationContainer.php
@@ -167,6 +167,7 @@ class AnnotationContainer implements interfaceAnnotationContainer
 
         // Update the datastream
         $contentJson["first"]["items"] = $items;
+        $contentJson["total"] = $contentJson["total"] - 1;
         $updatedContent = json_encode($contentJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
         $WADMObject->content = $updatedContent;
 
@@ -199,10 +200,10 @@ class AnnotationContainer implements interfaceAnnotationContainer
             $items = $contentJson["first"]["items"];
             array_push($items, $annotationPID);
             $contentJson["first"]["items"] = $items;
+            $contentJson["total"] = $contentJson["total"] + 1;
             $newContent = json_encode($contentJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
             $WADMObject->content = $newContent;
-
-            watchdog(AnnotationConstants::MODULE_NAME , 'AnnotationContainer : addContainerItem: Added the following item to the container: @annotationContainerID' , array("@annotationContainerID" => $annotationContainerID), WATCHDOG_INFO);
+            watchdog(AnnotationConstants::MODULE_NAME, 'AnnotationContainer : addContainerItem: Added the following item to the container: @annotationContainerID' , array("@annotationContainerID" => $annotationContainerID), WATCHDOG_INFO);
         } catch(Exception $e){
             watchdog(AnnotationConstants::MODULE_NAME, 'AnnotationContainer : addContainerItem: Failed to add new item to the container: %t', array('%t' => $e->getMessage()), WATCHDOG_ERROR);
             throw $e;

--- a/includes/AnnotationContainer.php
+++ b/includes/AnnotationContainer.php
@@ -37,13 +37,14 @@ class AnnotationContainer implements interfaceAnnotationContainer
             $object->relationships->add(FEDORA_RELS_EXT_URI, 'isMemberOfCollection', AnnotationConstants::WADMContainer_CONTENT_MODEL);
             $object->relationships->add(FEDORA_RELS_EXT_URI, 'isAnnotationContainerOf', $targetObjectID);
             $dsid = AnnotationConstants::WADMContainer_DSID;
+            $annotationContainerPID =  $object->id;
 
             $ds = $object->constructDatastream($dsid, 'M');
             $ds->label = $dsid;
             $ds->mimetype = AnnotationConstants::ANNOTATION_MIMETYPE;
 
             $targetPageID = $target . "/annotations/?page=0";
-            $test = $this->getAnnotationContainerJsonLD($targetObjectID, $targetPageID);
+            $test = $this->getAnnotationContainerJsonLD($annotationContainerPID, $targetObjectID, $targetPageID);
             $ds->setContentFromString($test);
             $object->ingestDatastream($ds);
             $this->repository->ingestObject($object);
@@ -210,11 +211,12 @@ class AnnotationContainer implements interfaceAnnotationContainer
 
     }
 
-    private function getAnnotationContainerJsonLD($targetObjectID, $targetPageID)
+    private function getAnnotationContainerJsonLD($annotationContainerPID, $targetObjectID, $targetPageID)
     {
-        $containerID = AnnotationUtil::generateUUID();
+      global $base_url;
+      $containerID = $base_url . "/islandora/object/" . $annotationContainerPID;
 
-        $data = array(
+      $data = array(
             "@context" => array(AnnotationConstants::ONTOLOGY_CONTEXT_ANNOTATION, AnnotationConstants::ONTOLOGY_CONTEXT_LDP),
             "@id" => $containerID,
             "@type" => array("BasicContainer", "AnnotationCollection"),

--- a/includes/AnnotationContainerTracker.php
+++ b/includes/AnnotationContainerTracker.php
@@ -86,7 +86,8 @@ class AnnotationContainerTracker {
     return $annotationContainerID;
   }
 
-  private function cleanupInProcessList($targetObjectID){
+  public function cleanupInProcessList($targetObjectID) {
+
     $currentList  = variable_get('islandora_web_annotations_inprocess');
     $pids = explode("||", $currentList);
     $newList = array_diff($pids, array($targetObjectID));

--- a/includes/AnnotationController.php
+++ b/includes/AnnotationController.php
@@ -53,6 +53,7 @@ function createAnnotationForVideo($json){
     $user = $annotationData["user"];
     $annotationMetadata["created"] = $created;
     $annotationMetadata["creator"] = $user;
+    $annotationMetadata["targetFormat"] = "video";
 
     $targetPID = substr($uri, strrpos($uri, '/') + 1);
     $oAnnotationContainer = new AnnotationContainer();
@@ -143,6 +144,7 @@ function updateAnnotation(){
             $annotationMetadata["created"] = $created;
             $annotationMetadata["creator"] = $user;
             $annotationMetadata["author"] = $author;
+            $annotationMetadata["targetFormat"] = "video";
 
             $annotationID  = $annotationData["pid"];
             $ETag = $annotationData["checksum"];

--- a/includes/AnnotationFormatTranslator.php
+++ b/includes/AnnotationFormatTranslator.php
@@ -14,15 +14,15 @@
  */
 function convert_annotorious_to_W3C_annotation_datamodel($annotationData, $data) {
 
+  // target
   $shapes = $annotationData["shapes"];
   $target_source = $annotationData["src"];
-
-  // $target_source_relative_path = parse_url($target_source)["path"];
-  $bodytext = $annotationData["text"];
-
-  $target = array('source' => $target_source, 'format' => 'image', 'selector' => array('shapes' => $shapes));
-
+  $selector_ext_jsonld = "http://ontology.digitalscholarship.utsc.utoronto.ca/ns/anno_extension.jsonld";
+  $target = array('source' => $target_source, 'format' => 'image', 'selector' => array('@context' => $selector_ext_jsonld, 'shapes' => $shapes));
   $data["target"] = $target;
+
+  // body
+  $bodytext = $annotationData["text"];
   $data["body"] = array('type' => 'TextualBody', 'bodytext' => $bodytext, 'format' => 'text/plain');
 
   return $data;
@@ -39,17 +39,18 @@ function convert_annotorious_to_W3C_annotation_datamodel($annotationData, $data)
 
 function convert_ova_to_W3C_annotation_datamodel($annotationData, $data) {
 
-  $bodytext = $annotationData["text"];
+  // target
   $media = $annotationData["media"];
   $rangeTime = $annotationData["rangeTime"];
-
   $target_org = $annotationData["target"];
   $target_source = $target_org["src"];
   $container = $target_org["container"];
-
-  $target = array('source' => $target_source, 'format' => $media, 'selector' => array('rangeTime' => $rangeTime), 'container' => $container);
+  $selector_ext_jsonld = "http://ontology.digitalscholarship.utsc.utoronto.ca/ns/anno_extension.jsonld";
+  $target = array('source' => $target_source, 'format' => $media, 'selector' => array('@context' => $selector_ext_jsonld, 'rangeTime' => $rangeTime), 'container' => $container);
   $data["target"] = $target;
 
+  // body
+  $bodytext = $annotationData["text"];
   $data["body"] = array('type' => 'TextualBody', 'bodytext' => $bodytext, 'format' => 'text/html');
 
   return $data;

--- a/includes/AnnotationFormatTranslator.php
+++ b/includes/AnnotationFormatTranslator.php
@@ -70,12 +70,21 @@ function conver_W3C_to_lib_annotation_datamodel($dsContentJson) {
   $annoObject->text = $dsContentJson->body->bodytext;
   $annoObject->media = $dsContentJson->target->format;
   $annoObject->pid = $dsContentJson->{"@id"};
-  $annoObject->creator = $dsContentJson->creator;
+
+  $userURL = $dsContentJson->creator;
+
+  $userInfo = explode('/', $userURL);
+  if(sizeof($userInfo) > 1) {
+    $userName = $userInfo[sizeof($userInfo) - 1];
+  } else {
+    $userName = $userURL;
+  }
+  $annoObject->creator = $userName;
   $annoObject->created = $dsContentJson->created;
 
   if ((strpos($targetFormat, 'audio') !== false) || (strpos($targetFormat, 'video') !== false)) {
     $annoObject->rangeTime = $dsContentJson->target->selector->rangeTime;
-    $annoObject->user = $dsContentJson->creator;
+    $annoObject->user = $userName;
     $target_source = $dsContentJson->target->source;
     $container = $dsContentJson->target->container;
     if ($container == null) {

--- a/includes/AnnotationFormatTranslator.php
+++ b/includes/AnnotationFormatTranslator.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * @file
+ * Handles annotation data object data model format transformations.
+ */
+
+/**
+ * Converts an annotorious annotation object into a W3C compliant data object.
+ *
+ * @param object $annotationData
+ * @param object $data
+ * @return object
+ */
+function convert_annotorious_to_W3C_annotation_datamodel($annotationData, $data) {
+
+  $shapes = $annotationData["shapes"];
+  $target_source = $annotationData["src"];
+
+  $target_source_relative_path = parse_url($target_source)["path"];
+  $bodytext = $annotationData["text"];
+
+  $target = array('source' => $target_source_relative_path, 'format' => 'image', 'selector' => array('shapes' => $shapes));
+
+  $data["target"] = $target;
+  $data["body"] = array('type' => 'TextualBody', 'bodytext' => $bodytext, 'format' => 'text/plain');
+
+  return $data;
+
+}
+
+/**
+ * Converts an Open Video Annotation (annotator.js) annotation object into a W3C compliant data object.
+ *
+ * @param object $annotationData
+ * @param object $data
+ * @return object
+ */
+
+function convert_ova_to_W3C_annotation_datamodel($annotationData, $data) {
+
+  $bodytext = $annotationData["text"];
+  $media = $annotationData["media"];
+  $rangeTime = $annotationData["rangeTime"];
+
+  $target_org = $annotationData["target"];
+  $target_source = $target_org["src"];
+
+  $target = array('source' => $target_source, 'format' => $media, 'selector' => array('rangeTime' => $rangeTime));
+  $data["target"] = $target;
+
+  $data["body"] = array('type' => 'TextualBody', 'bodytext' => $bodytext, 'format' => 'text/html');
+
+  return $data;
+}
+
+/**
+ * Converts a W3C annotation data object into library specific (annotorious for image, ova for video) data object.
+ *
+ * @param $dsContentJson
+ * @return \stdClass
+ */
+function conver_W3C_to_lib_annotation_datamodel($dsContentJson) {
+
+  $targetFormat = $dsContentJson->target->format;
+
+  $annoObject = new stdClass;
+  $annoObject->text = $dsContentJson->body->bodytext;
+  $annoObject->media = $dsContentJson->target->format;
+  $annoObject->pid = $dsContentJson->{"@id"};
+  $annoObject->creator = $dsContentJson->creator;
+  $annoObject->created = $dsContentJson->created;
+
+  if ($targetFormat == "video") {
+    $annoObject->rangeTime = $dsContentJson->target->selector->rangeTime;
+    $annoObject->user = $dsContentJson->creator;
+    $target_source = $dsContentJson->target->source;
+    $target = array('src' => $target_source, 'ext' => $target_source, 'container' => 'islandora_videojs');
+    $annoObject->target = $target;
+  } else if ($targetFormat == "image") {
+    $annoObject->shapes = $dsContentJson->target->selector->shapes;
+    $annoObject->src = $dsContentJson->target->source;
+  }
+  return $annoObject;
+}

--- a/includes/AnnotationFormatTranslator.php
+++ b/includes/AnnotationFormatTranslator.php
@@ -17,10 +17,10 @@ function convert_annotorious_to_W3C_annotation_datamodel($annotationData, $data)
   $shapes = $annotationData["shapes"];
   $target_source = $annotationData["src"];
 
-  $target_source_relative_path = parse_url($target_source)["path"];
+  // $target_source_relative_path = parse_url($target_source)["path"];
   $bodytext = $annotationData["text"];
 
-  $target = array('source' => $target_source_relative_path, 'format' => 'image', 'selector' => array('shapes' => $shapes));
+  $target = array('source' => $target_source, 'format' => 'image', 'selector' => array('shapes' => $shapes));
 
   $data["target"] = $target;
   $data["body"] = array('type' => 'TextualBody', 'bodytext' => $bodytext, 'format' => 'text/plain');
@@ -45,6 +45,10 @@ function convert_ova_to_W3C_annotation_datamodel($annotationData, $data) {
 
   $target_org = $annotationData["target"];
   $target_source = $target_org["src"];
+
+  global $base_url;
+  $target_source = $base_url . $target_source;
+
 
   $target = array('source' => $target_source, 'format' => $media, 'selector' => array('rangeTime' => $rangeTime));
   $data["target"] = $target;

--- a/includes/AnnotationFormatTranslator.php
+++ b/includes/AnnotationFormatTranslator.php
@@ -23,7 +23,7 @@ function convert_annotorious_to_W3C_annotation_datamodel($annotationData, $data)
 
   // body
   $bodytext = $annotationData["text"];
-  $data["body"] = array('type' => 'TextualBody', 'bodyValue' => $bodytext, 'format' => 'text/plain');
+  $data["body"] = array('@type' => 'TextualBody', 'bodyValue' => $bodytext, 'format' => 'text/plain');
 
   return $data;
 
@@ -51,7 +51,7 @@ function convert_ova_to_W3C_annotation_datamodel($annotationData, $data) {
 
   // body
   $bodytext = $annotationData["text"];
-  $data["body"] = array('type' => 'TextualBody', 'bodyValue' => $bodytext, 'format' => 'text/html');
+  $data["body"] = array('@type' => 'TextualBody', 'bodyValue' => $bodytext, 'format' => 'text/html');
 
   return $data;
 }

--- a/includes/AnnotationFormatTranslator.php
+++ b/includes/AnnotationFormatTranslator.php
@@ -45,12 +45,9 @@ function convert_ova_to_W3C_annotation_datamodel($annotationData, $data) {
 
   $target_org = $annotationData["target"];
   $target_source = $target_org["src"];
+  $container = $target_org["container"];
 
-  global $base_url;
-  $target_source = $base_url . $target_source;
-
-
-  $target = array('source' => $target_source, 'format' => $media, 'selector' => array('rangeTime' => $rangeTime));
+  $target = array('source' => $target_source, 'format' => $media, 'selector' => array('rangeTime' => $rangeTime), 'container' => $container);
   $data["target"] = $target;
 
   $data["body"] = array('type' => 'TextualBody', 'bodytext' => $bodytext, 'format' => 'text/html');
@@ -75,13 +72,17 @@ function conver_W3C_to_lib_annotation_datamodel($dsContentJson) {
   $annoObject->creator = $dsContentJson->creator;
   $annoObject->created = $dsContentJson->created;
 
-  if ($targetFormat == "video") {
+  if ((strpos($targetFormat, 'audio') !== false) || (strpos($targetFormat, 'video') !== false)) {
     $annoObject->rangeTime = $dsContentJson->target->selector->rangeTime;
     $annoObject->user = $dsContentJson->creator;
     $target_source = $dsContentJson->target->source;
-    $target = array('src' => $target_source, 'ext' => $target_source, 'container' => 'islandora_videojs');
+    $container = $dsContentJson->target->container;
+    if ($container == null) {
+      $container = "islandora_videojs";
+    }
+    $target = array('src' => $target_source, 'ext' => $target_source, 'container' => $container);
     $annoObject->target = $target;
-  } else if ($targetFormat == "image") {
+  } else if (strpos($targetFormat, 'image') !== false) {
     $annoObject->shapes = $dsContentJson->target->selector->shapes;
     $annoObject->src = $dsContentJson->target->source;
   }

--- a/includes/AnnotationFormatTranslator.php
+++ b/includes/AnnotationFormatTranslator.php
@@ -17,8 +17,9 @@ function convert_annotorious_to_W3C_annotation_datamodel($annotationData, $data)
   // target
   $shapes = $annotationData["shapes"];
   $target_source = $annotationData["src"];
+
   $selector_ext_jsonld = "http://ontology.digitalscholarship.utsc.utoronto.ca/ns/anno_extension.jsonld";
-  $target = array('source' => $target_source, 'format' => 'image', 'selector' => array('@context' => $selector_ext_jsonld, 'shapes' => $shapes));
+  $target = array('@id' => $annotationData['context'], 'source' => $target_source, 'format' => 'image', 'selector' => array('@context' => $selector_ext_jsonld, 'shapes' => $shapes));
   $data["target"] = $target;
 
   // body
@@ -50,7 +51,7 @@ function convert_ova_to_W3C_annotation_datamodel($annotationData, $data) {
 
   $container = $target_org["container"];
   $selector_ext_jsonld = "http://ontology.digitalscholarship.utsc.utoronto.ca/ns/anno_extension.jsonld";
-  $target = array('source' => $target_source, 'format' => $media, 'selector' => array('@context' => $selector_ext_jsonld, 'rangeTime' => $rangeTime), 'container' => $container);
+  $target = array('@id' => $annotationData['context'], 'source' => $target_source, 'format' => $media, 'selector' => array('@context' => $selector_ext_jsonld, 'rangeTime' => $rangeTime), 'container' => $container);
   $data["target"] = $target;
 
   // body

--- a/includes/AnnotationFormatTranslator.php
+++ b/includes/AnnotationFormatTranslator.php
@@ -44,6 +44,10 @@ function convert_ova_to_W3C_annotation_datamodel($annotationData, $data) {
   $rangeTime = $annotationData["rangeTime"];
   $target_org = $annotationData["target"];
   $target_source = $target_org["src"];
+
+  global $base_url;
+  $target_source = $base_url . $target_source;
+
   $container = $target_org["container"];
   $selector_ext_jsonld = "http://ontology.digitalscholarship.utsc.utoronto.ca/ns/anno_extension.jsonld";
   $target = array('source' => $target_source, 'format' => $media, 'selector' => array('@context' => $selector_ext_jsonld, 'rangeTime' => $rangeTime), 'container' => $container);

--- a/includes/AnnotationFormatTranslator.php
+++ b/includes/AnnotationFormatTranslator.php
@@ -23,7 +23,7 @@ function convert_annotorious_to_W3C_annotation_datamodel($annotationData, $data)
 
   // body
   $bodytext = $annotationData["text"];
-  $data["body"] = array('type' => 'TextualBody', 'bodytext' => $bodytext, 'format' => 'text/plain');
+  $data["body"] = array('type' => 'TextualBody', 'bodyValue' => $bodytext, 'format' => 'text/plain');
 
   return $data;
 
@@ -51,7 +51,7 @@ function convert_ova_to_W3C_annotation_datamodel($annotationData, $data) {
 
   // body
   $bodytext = $annotationData["text"];
-  $data["body"] = array('type' => 'TextualBody', 'bodytext' => $bodytext, 'format' => 'text/html');
+  $data["body"] = array('type' => 'TextualBody', 'bodyValue' => $bodytext, 'format' => 'text/html');
 
   return $data;
 }
@@ -67,7 +67,7 @@ function conver_W3C_to_lib_annotation_datamodel($dsContentJson) {
   $targetFormat = $dsContentJson->target->format;
 
   $annoObject = new stdClass;
-  $annoObject->text = $dsContentJson->body->bodytext;
+  $annoObject->text = $dsContentJson->body->bodyValue;
   $annoObject->media = $dsContentJson->target->format;
   $annoObject->pid = $dsContentJson->{"@id"};
 

--- a/includes/AnnotationUtil.php
+++ b/includes/AnnotationUtil.php
@@ -102,7 +102,7 @@ class AnnotationUtil
     /**
      *  Returns datetime as a xsd:dateTime with the UTC timezone expressed as "Z".
      */
-    public function utcNow() {
+    public static function utcNow() {
       $now = date("Y-m-d H:i:s");
       $utc_now = new DateTime($now);
       $utc_now->setTimezone(new DateTimeZone('UTC'));

--- a/includes/AnnotationUtil.php
+++ b/includes/AnnotationUtil.php
@@ -99,6 +99,29 @@ class AnnotationUtil
         return $targetPID;
     }
 
+  /**
+   * Returns the PID from a URL.
+   *
+   * @param string $url
+   *   Canonoical url of the source.
+   * @return string $targetPID
+   */
+    public static function getPIDfromCanonicalURL($url) {
+
+      // Clean URL
+      $url = str_replace("%3A",":",$url);
+
+      // Get Path
+      $urlInfo = parse_url($url);
+      $path = $urlInfo['path'];
+
+      // Get PID from path /islandora/object/pid
+      $pathInfo = explode("/", $path);
+      $targetPID = $pathInfo[3];
+
+      return $targetPID;
+    }
+
     /**
      *  Returns datetime as a xsd:dateTime with the UTC timezone expressed as "Z".
      */

--- a/islandora_web_annotations.module
+++ b/islandora_web_annotations.module
@@ -235,7 +235,7 @@ function islandora_web_annotations_islandora_object_alter(AbstractObject $object
         $content = $WADM_SEARCH_Object->content;
         $contentJson = json_decode($content);
         $targetURL = $contentJson->target->source;
-        $targetPID = AnnotationUtil::getPIDfromURL($targetURL);
+        $targetPID = AnnotationUtil::getPIDfromCanonicalURL($targetURL);
 
         // Get the container
         $oAnnotationContainer = new AnnotationContainer();

--- a/islandora_web_annotations.module
+++ b/islandora_web_annotations.module
@@ -244,6 +244,10 @@ function islandora_web_annotations_islandora_object_alter(AbstractObject $object
         // Remove the annotation from the container
         $annoID = $object->id;
         $oAnnotationContainer->removeItem($annotationContainerID, $annoID);
+
+        // Clean up AnnotationContainers tracking list
+        $annotationContainerTracker = new AnnotationContainerTracker();
+        $annotationContainerTracker->cleanupInProcessList($targetPID);
       }
       catch (Exception $e) {
         watchdog(AnnotationConstants::MODULE_NAME, 'Error in updating AnnotationContainer after deleting an annotation: %t', array('%t' => $e->getMessage()), WATCHDOG_ERROR);

--- a/islandora_web_annotations.module
+++ b/islandora_web_annotations.module
@@ -234,7 +234,7 @@ function islandora_web_annotations_islandora_object_alter(AbstractObject $object
         $WADM_SEARCH_Object = $object->getDatastream("WADM");
         $content = $WADM_SEARCH_Object->content;
         $contentJson = json_decode($content);
-        $targetURL = $contentJson->target;
+        $targetURL = $contentJson->target->source;
         $targetPID = AnnotationUtil::getPIDfromURL($targetURL);
 
         // Get the container

--- a/islandora_web_annotations.module
+++ b/islandora_web_annotations.module
@@ -234,8 +234,8 @@ function islandora_web_annotations_islandora_object_alter(AbstractObject $object
         $WADM_SEARCH_Object = $object->getDatastream("WADM");
         $content = $WADM_SEARCH_Object->content;
         $contentJson = json_decode($content);
-        $targetURL = $contentJson->target->source;
-        $targetPID = AnnotationUtil::getPIDfromCanonicalURL($targetURL);
+        $targetURL = $contentJson->target->{"@id"};
+        $targetPID = AnnotationUtil::getPIDfromURL($targetURL);
 
         // Get the container
         $oAnnotationContainer = new AnnotationContainer();

--- a/js/base/base.js
+++ b/js/base/base.js
@@ -32,6 +32,7 @@ function createAnnotation(targetObjectId, annotationData) {
     var user = Drupal.settings.islandora_web_annotations.user;
     var metadata = {}
     metadata.creator = user;
+    metadata.targetFormat = "image";
 
     // Ensure that canonical path is saved, not path autho
     annotationData.context = g_contentURI;
@@ -186,10 +187,11 @@ function updateAnnotation(annotationData) {
     var created = annotationData.created;
     var checksum = annotationData.checksum;
 
-    var metadata = {}
+    var metadata = {};
     metadata.author = user;
     metadata.creator = creator;
     metadata.created = created;
+    metadata.targetFormat = "image";
 
     // Do not want data duplicated
     delete annotationData.creator;

--- a/js/base/base.js
+++ b/js/base/base.js
@@ -35,7 +35,7 @@ function createAnnotation(targetObjectId, annotationData) {
     metadata.targetFormat = "image";
 
     // Ensure that canonical path is saved, not path autho
-    annotationData.context = g_contentURI;
+    annotationData.context = g_targetURL;
 
     var annotation = {
         targetPid: targetObjectId,
@@ -199,7 +199,7 @@ function updateAnnotation(annotationData) {
     delete annotationData.checksum;
 
     // Ensure that canonical path is saved, not path autho
-    annotationData.context = g_contentURI;
+    annotationData.context = g_targetURL;
 
     var annotationPID = annotationData.pid;
     var annotation = {

--- a/js/basic_image/basic_image.js
+++ b/js/basic_image/basic_image.js
@@ -6,7 +6,7 @@
  */
 
 var g_contentType = "basic-image";
-var g_contentURI = window.location.href;
+var g_targetURL = window.location.href;
 
 jQuery(document).ready(function() {
     var image_position = jQuery(".islandora-basic-image-content img").position();
@@ -99,7 +99,7 @@ function getAnnotationsBasicImage() {
 
 function getBasicImagePID() {
     var objectPID = Drupal.settings.islandora_web_annotations.pid;
-    g_contentURI = location.protocol + '//' + location.host + "/islandora/object/" + objectPID
+    g_targetURL = location.protocol + '//' + location.host + "/islandora/object/" + objectPID
     return objectPID;
 }
 

--- a/js/large_image/large_image.js
+++ b/js/large_image/large_image.js
@@ -6,7 +6,7 @@
  */
 
 var g_contentType = "large-image";
-var g_contentURI = window.location.href;
+var g_targetURL = window.location.href;
 
 jQuery(document).ready(function() {
 
@@ -35,6 +35,7 @@ jQuery(document).ready(function() {
         saveButton.appendTo(jQuery("#openseadragon-wrapper"));
 
         if(Drupal.settings.islandora_web_annotations.load_true == true){
+            setContentURI();
             getAnnotationsLargeImage();
         }
     }
@@ -42,6 +43,7 @@ jQuery(document).ready(function() {
     if(Drupal.settings.islandora_web_annotations.create == true) {
         var addButton = jQuery('<button id="add-annotation-button" title="Add Annotation" class="annotator-adder-actions__button h-icon-add" onclick="anno.activateSelector();"></button>');
         addButton.appendTo(jQuery("#openseadragon-wrapper"));
+        setContentURI();
     }
 
 
@@ -88,6 +90,10 @@ jQuery(document).ready(function() {
 
 function getAnnotationsLargeImage() {
     var objectPID = Drupal.settings.islandora_web_annotations.pid;
-    g_contentURI = location.protocol + '//' + location.host + "/islandora/object/" + objectPID
     getAnnotations(objectPID);
+}
+
+function setContentURI() {
+    var objectPID = Drupal.settings.islandora_web_annotations.pid;
+    g_targetURL = location.protocol + '//' + location.host + "/islandora/object/" + objectPID
 }


### PR DESCRIPTION
!Warning! This PR introduces backward breaking changed.  You won't be work with existing annotations after applying this PR because it changes the structure of the jsonld.

# What does this Pull Request do?
This is a major cleanup of the jsonld for annotation datastream (WADM).  Some notable changes are:
* Removed the UUID for @id.  Instead using canonical url of the annotation (pid).
* body and target are properly structured
* duplicate target/context info has been removed
* As per https://www.w3.org/TR/annotation-vocab/, "http://ontology.digitalscholarship.utsc.utoronto.ca/ns/anno_extension.jsonld" context added to selector to support image and video timespan selection.  Thanks to Kim for pointing this out.

Known issues:
* target body format is not a fully qualified mime type.  For video/audio, we are using the values from the OpenVideoAnnotation library.  When a finer mime type can be specified, the module will should work without any issues.
* We have one additional property that is not in the anno.jsonld: modifiedBy.  This is just an additional piece of information we are tracking.  Not being used by the application.  We can simply remove this property.  

# How should this be tested?
* Get the PR
* Do Sanity tests (CRUD) for each content type (Basic Image, Large Image, Paged Content, Audio, Video, Oral History)
* Verify WADM and WADM_SEARCH datasteams (WADM should confirm to the jsonld standards with the above exceptions)


