### PR TITLE
Force selection of annotation namespace

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -46,8 +46,9 @@ function islandora_web_annotations_admin(array $form, array &$form_state) {
   $form['islandora_web_annotations_namespace'] = array(
       '#type' => 'textfield',
       '#title' => t('Annotation Namespace'),
-      '#description' => t('Sets the namespace to use for annotation objects.  Defaults to \'annotation.\''),
-      '#default_value' => variable_get('islandora_web_annotations_namespace', 'annotation'),
+      '#description' => t('Please carefully select the namespace to use for annotation objects.'),
+      '#default_value' => variable_get('islandora_web_annotations_namespace'),
+      '#required' => TRUE,
   );
   $form['islandora_web_annotations_isannotationcontainerof_solr_field'] = array(
       '#type' => 'textfield',

--- a/islandora_web_annotations.install
+++ b/islandora_web_annotations.install
@@ -25,6 +25,7 @@ function islandora_web_annotations_uninstall() {
     module_load_include('inc', 'islandora', 'includes/solution_packs');
     $variables = array(
       'islandora_web_annotations_verbose',
+      'islandora_web_annotations_namespace',
     );
     array_map('variable_del', $variables);
     islandora_install_solution_pack('islandora_web_annotations', 'uninstall');


### PR DESCRIPTION
# What does this Pull Request do?
Removes the default annotation namespace setting and makes filling this configuration setting required. See issue #220.
# What's new?
Does not pre-fill the annotation namespace configuration setting and also makes this setting required.  Updates the form language for this setting too.

# How should this be tested?
* If a prior version of the Web annotations module is installed, uninstall the module. 
* Pull the changes and reinstall the module.  If the Annotation Namespace setting is prefilled, uninstall the module again as this update clears the annotation namespace variable from the variables table on uninstall.
* Reinstall (enable) the module.
* In the Web Annotations module configuration, the  Annotation Namespace textfield should be empty.  
* Attempt to save the form without filling out this textfied.  You should see a message saying that  the Annotation Namespace is required.
* Fill out the  Annotation Namespace textfield with your desired annotation namespace.  You should be able to save the configuration. 
* Create a new annotation - the new annotation object should use the namespace used in the  Annotation Namespace configuration setting.

# Additional Notes:
@Natkeeran  It would be good to check that we remove other Web Annotation variables that are saved to Drupal's variables table on module uninstall.
