### PR TITLE
Updates Travis configuration to use precise build for PHP 5.3.3.  See…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ branches:
     - 7.x
 
 env:
+  - FEDORA_VERSION="3.5"
+  - FEDORA_VERSION="3.6.2"
+  - FEDORA_VERSION="3.7.0"
   - FEDORA_VERSION="3.8.1"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,23 @@ sudo: true
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+
+matrix:
+  include:
+    - php: "5.3.3"
+      dist: precise
+      env: FEDORA_VERSION="3.5"
+    - php: "5.3.3"
+      dist: precise
+      env: FEDORA_VERSION="3.6.2"
+    - php: "5.3.3"
+      dist: precise
+      env: FEDORA_VERSION="3.7.0"
+    - php: "5.3.3"
+      dist: precise
+      env: FEDORA_VERSION="3.8.1"
 
 branches:
   only:


### PR DESCRIPTION
Adds a build matrix that uses the `precise` distribution for testing against PHP 5.3.3.   See issue https://github.com/digitalutsc/islandora_web_annotations/issues/226.

# What does this Pull Request do?
This pull request updates the Travis build file to reflect default changes with the Travis CI service.

# How should this be tested?
Let Travis CI run against this pull request.  The build should complete successfully.
