### PR TITLE
play annotation when loaded from search

### DIFF
--- a/js/video/video.js
+++ b/js/video/video.js
@@ -123,7 +123,43 @@ jQuery(document).ready(function() {
         applyBlock("created");
     });
 
+    askIfUserWantsToPlay();
 });
+
+/**
+ * If the page gets loaded from search results, provide the user option to play the annotation.
+ */
+function askIfUserWantsToPlay() {
+
+    jQuery.blockUI({
+        message: "Would you like to play the video annotation? <br><span id='yes_play'>Yes</span> &nbsp;&nbsp;&nbsp;&nbsp;<span id='do_not_play'>No</span>",
+        fadeIn: 700,
+        fadeOut: 700,
+        timeout: 3000,
+        showOverlay: false,
+        centerY: false,
+        css: {
+            height: '50px',
+            border: 'none',
+            padding: '5px',
+            backgroundColor: '#000',
+            '-webkit-border-radius': '10px',
+            '-moz-border-radius': '10px',
+            opacity: .6,
+            color: '#fff'
+        }
+    });
+
+    jQuery('#yes_play').click(function() {
+        jQuery.unblockUI();
+        var annotationPID = getParameterByName("annotationPID");
+        ova.playTarget(annotationPID);
+    });
+
+    jQuery('#do_not_play').click(function() {
+        jQuery.unblockUI();
+    });
+}
 
 function applyPermissionsOnView(annotations){
 
@@ -316,4 +352,22 @@ function showGrowlMsg(i_msg) {
         }
     });
 
+}
+
+
+/**
+ * Utility method
+ *
+ * @param param_name
+ * @param url
+ * @returns {*}
+ */
+function getParameterByName(param_name, url) {
+    if (!url) url = window.location.href;
+    param_name = param_name.replace(/[\[\]]/g, "\\$&");
+    var regex = new RegExp("[?&]" + param_name + "(=([^&#]*)|&|#|$)"),
+        results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, " "));
 }


### PR DESCRIPTION
# What does this Pull Request do?
* https://github.com/digitalutsc/islandora_web_annotations/issues/186

When the user comes an object via the search (https://github.com/digitalutsc/islandora_web_annotations/issues/201), it will provide the option to play that annotation.

# How should this be tested?
* Get the PR & merge it with the base (Note that you need to merge this)
* You will need to set up search (https://github.com/digitalutsc/islandora_web_annotations/issues/201).  
* From search, click on the parent link, go to a video/audio object
* Should provide you option to play the annotation, and when clicked yes, play the annotation

# Interested parties
@MarcusBarnes 
