### PR TITLE
ensure to show the dialog if from search

### DIFF
--- a/js/video/video.js
+++ b/js/video/video.js
@@ -123,7 +123,9 @@ jQuery(document).ready(function() {
         applyBlock("created");
     });
 
-    askIfUserWantsToPlay();
+    if (window.location.href.indexOf("annotationPID") > -1) {
+        askIfUserWantsToPlay();
+    }
 
     // Play video when button clicked from View
     jQuery(".playvideo").click(function() {


### PR DESCRIPTION
# What does this Pull Request do?
This is a regression issue from PR https://github.com/digitalutsc/islandora_web_annotations/pull/242.  The dialogue is shown even if the user does not come from search and does not have pid reference.  This PR checks to make only show the dialogue if the user is coming from search.

# How should this be tested?
* Setup search customization as described here: https://github.com/digitalutsc/islandora_web_annotations/issues/201
* Go to a video annotation page via search value - the dialogue should show
* Go to a video annotation page by navigating from repository or other means - the dialogue should not show

# Interested parties
@MarcusBarnes 
