### PR TITLE
ensure audio start and end times are indexed

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -50,7 +50,7 @@ function generateDerivativeContent($wadmObj) {
   $xml->addChild('creator', $creator);
   addCDATAchild('textvalue', $textvalue, $xml);
 
-  if ($wadmObj["target"]["format"] == "video") {
+  if ($wadmObj["target"]["format"] == "video" || $wadmObj["target"]["format"] == "audio") {
     $rangeTimeStart = $wadmObj["target"]["selector"]["rangeTime"]["start"];
     $xml->addChild('rangeTimeStart', $rangeTimeStart);
     $rangeTimeEnd = $wadmObj["target"]["selector"]["rangeTime"]["end"];


### PR DESCRIPTION
# What does this Pull Request do?
Resolves the following issue @MarcusBarnes discovered while testing: the audio annotation view does not contain start and end times.  

# What's new?
Ensures that both audio and video have start and end time indexed.

# How should this be tested?
* Get the PR
* Create an audio object and create annotations.  Ensure that Islandora Web Annotation Block - Audio, Video block for the audio annotations contain start and end time values.

# Interested parties
@MarcusBarnes 
