### PR TITLE
hide timepanel after create/update

### DIFF
--- a/js/video/video.js
+++ b/js/video/video.js
@@ -217,6 +217,7 @@ jQuery(document).ajaxComplete(function(event, jqXHR, ajaxOptions) {
             var short_message = "Error in creating the annotation.";
             verbose_alert(short_message, verbose_message);
         }
+        jQuery(".vjs-controltimepanel-RS").hide();
 
     } else if (ajaxOptions.type === 'PUT' && /\/islandora_web_annotations/.test(ajaxOptions.url)) {
         jQuery('.annotator-wrapper').unblock();
@@ -245,6 +246,7 @@ jQuery(document).ajaxComplete(function(event, jqXHR, ajaxOptions) {
             var short_message = "Error: Unable to update.";
             verbose_alert(short_message, verbose_message);
         }
+        jQuery(".vjs-controltimepanel-RS").hide();
 
     } else if (ajaxOptions.type === 'DELETE' && /\/islandora_web_annotations/.test(ajaxOptions.url)) {
         var jsonData = JSON.parse(jsonDataText);


### PR DESCRIPTION
# What does this Pull Request do?
This PR hides the timepanel after an annotation is created or updated.  If the time panel is not hidden, other buttons goes out of the focus in small screens (i.e when both sidebars are active.)

# How should this be tested?
* Create/Update annotation in video.  Ensure that the timepanel is hidden after save.  Verify that when you create/update another annotation, the timepanel appears again.  

# Interested parties
@MarcusBarnes 
